### PR TITLE
Ensemble Initial Implementation

### DIFF
--- a/lsstseries/ensemble.py
+++ b/lsstseries/ensemble.py
@@ -87,12 +87,22 @@ class ensemble():
         cols = [time_col, flux_col, err_col]
 
         if to_mag:
-            query_cols, cols = self.flux_to_mag(cols)
+            flux_query, flux_label = self.flux_to_mag([flux_col])
+            flux_col = flux_label[0]
+            if err_col is not None:
+                err_query, err_label = self.flux_to_mag([err_col])
+                err_col = err_label[0]
+
+            query_cols = [time_col] + flux_query + err_query
+            cols = [time_col, flux_col, err_col]
+
         else:
             query_cols = cols
 
         if add_cols is not None:
             cols = cols+add_cols
+            query_cols = query_cols+add_cols
+
         idx_cols = ['diaObjectId', 'filterName']
 
         result = pd.DataFrame(columns=idx_cols+cols)

--- a/lsstseries/ensemble.py
+++ b/lsstseries/ensemble.py
@@ -1,41 +1,80 @@
 import pandas as pd
-import numpy as np
 import pyvo as vo
 from .timeseries import timeseries
 
+
 class ensemble():
     """ensemble object is a collection of light curve ids"""
-    def __init__(self,token=None):
-        self.result = None #holds the latest query
+    def __init__(self, token=None):
+        self.result = None  # holds the latest query
         self.token = token
 
     def tap_token(self, token):
         """Add/update a TAP token to the class, enables querying
         Read here for information on TAP access: https://data.lsst.cloud/api-aspect
-        """
-        self.token=token
 
-    def query_tap(self,query,maxrec=None):
-        """query the TAP service, query is an ADQL formatted string"""
+        Parameters
+        ----------
+        token : `str`
+            Token string
+        """
+        self.token = token
+
+    def query_tap(self, query, maxrec=None):
+        """Query the TAP service
+
+        Parameters
+        ----------
+        query : `str`
+            Query is an ADQL formatted string
+        maxrec: `int`
+            Max number of results returned
+
+        Returns
+        ----------
+        result: `pd.df`
+            Result of the query, as pandas dataframe
+        """
         cred = vo.auth.CredentialStore()
         cred.set_password("x-oauth-basic", self.token)
 
-        service = vo.dal.TAPService("https://data.lsst.cloud/api/tap",cred.get("ivo://ivoa.net/sso#BasicAA"))
+        service = vo.dal.TAPService("https://data.lsst.cloud/api/tap", cred.get("ivo://ivoa.net/sso#BasicAA"))
         results = service.search(query, maxrec=maxrec)
         result = results.to_table().to_pandas()
         self.result = result
         return result
 
-    def query_ids(self, ids, 
-                  core_cols=['midPointTai','psFlux','psFluxErr'],
+    def query_ids(self, ids,
+                  core_cols=['midPointTai', 'psFlux', 'psFluxErr'],
                   add_cols=[],
                   id_field='diaObjectId',
                   catalog='dp02_dc2_catalogs',
                   table='DiaSource',
                   maxrec=None):
-        """query based on a list of object ids"""
+        """Query based on a list of object ids; applicable for DP0.2
+
+        Parameters
+        ----------
+        ids: `int`
+            Ids of object
+        core_cols: `list` of `str`
+            Time, flux and flux error columns
+        add_cols: `list` of `str`
+            Additional colums to retreive
+        id_field: `str`
+            Which Id is being queried
+        catalog: `str`
+            Source catalog
+        table: `str`
+            Source table
+
+        Returns
+        ----------
+        result: `pd.df`
+            Result of the query, as pandas dataframe
+        """
         cols = core_cols+add_cols
-        idx_cols = ['diaObjectId','filterName']
+        idx_cols = ['diaObjectId', 'filterName']
 
         result = pd.DataFrame(columns=idx_cols+cols)
         select_cols = ",".join(idx_cols)+','+','.join(cols)
@@ -43,28 +82,40 @@ class ensemble():
         id_list = "("+",".join(str_ids)+")"
 
         result = self.query_tap(f"SELECT {select_cols} "
-                            f"FROM {catalog}.{table} "
-                            f"WHERE {id_field} IN {id_list}")
-        index = self._build_index(result['diaObjectId'],result['filterName'])
+                                f"FROM {catalog}.{table} "
+                                f"WHERE {id_field} IN {id_list}")
+        index = self._build_index(result['diaObjectId'], result['filterName'])
         result.index = index
         result = result[cols].sort_index()
         self.result = result
         return result
 
-    def to_timeseries(self,dataframe,target,core_cols=['midPointTai','psFlux','psFluxErr'],add_cols=[]):
-        """construct a timeseries object from one target object_id, assumes that the result
-        is a collection of lightcurves (output from query_ids)"""
-        cols = core_cols+add_cols
+    def to_timeseries(self, dataframe, target, core_cols=['midPointTai', 'psFlux', 'psFluxErr'], add_cols=[]):
+        """Construct a timeseries object from one target object_id, assumes that the result
+        is a collection of lightcurves (output from query_ids)
+
+        Parameters
+        ----------
+        dataframe: `pd.df`
+            Ensamble object
+        target: `int`
+            Id of a source to be extracted
+
+        Returns
+        ----------
+        ts: `timeseries`
+            Timeseries for a single object
+        """
+        # cols = core_cols + add_cols
         df = dataframe.xs(target)
-        ts = timeseries()._from_ensemble(data=df,object_id=target)
+        ts = timeseries()._from_ensemble(data=df, object_id=target)
         return ts
 
-    def _build_index(self,obj_id, band):
+    def _build_index(self, obj_id, band):
         """Build pandas multiindex from object_ids and bands"""
-        #Create a multiindex
+        # Create a multiindex
 
-        idx = range(len(list(zip(obj_id,band))))
-        tuples = zip(obj_id,band,idx)
-        index = pd.MultiIndex.from_tuples(tuples, names=["object_id","band", "index"])
+        idx = range(len(list(zip(obj_id, band))))
+        tuples = zip(obj_id, band, idx)
+        index = pd.MultiIndex.from_tuples(tuples, names=["object_id", "band", "index"])
         return index
-

--- a/lsstseries/ensemble.py
+++ b/lsstseries/ensemble.py
@@ -1,0 +1,70 @@
+import pandas as pd
+import numpy as np
+import pyvo as vo
+from .timeseries import timeseries
+
+class ensemble():
+    """ensemble object is a collection of light curve ids"""
+    def __init__(self,token=None):
+        self.table = None #holds the latest query
+        self.token = token
+
+    def tap_token(self, token):
+        self.token=token
+
+    def query_tap(self,query,maxrec=None):
+        cred = vo.auth.CredentialStore()
+        cred.set_password("x-oauth-basic", self.token)
+
+        service = vo.dal.TAPService("https://data.lsst.cloud/api/tap",cred.get("ivo://ivoa.net/sso#BasicAA"))
+        results = service.search(query, maxrec=maxrec)
+        result = results.to_table().to_pandas()
+        self.table = result
+        return result
+
+    def query_ids(self, ids, 
+                  core_cols=['midPointTai','psFlux','psFluxErr'],
+                  add_cols=[],
+                  id_field='diaObjectId',
+                  catalog='dp02_dc2_catalogs',
+                  table='DiaSource',
+                  maxrec=None):
+        cols = core_cols+add_cols
+        idx_cols = ['diaObjectId','filterName']
+
+        result = pd.DataFrame(columns=idx_cols+cols)
+        select_cols = ",".join(idx_cols)+','+','.join(cols)
+        str_ids = [str(obj_id) for obj_id in ids]
+        id_list = "("+",".join(str_ids)+")"
+        """
+        for obj_id in ids:
+            id_result = self.query_tap(f"SELECT {select_cols} "
+                            f"FROM {catalog}.{table} "
+                            f"WHERE diaObjectId={obj_id}")
+            result = pd.concat([result,id_result])
+        """
+
+        result = self.query_tap(f"SELECT {select_cols} "
+                            f"FROM {catalog}.{table} "
+                            f"WHERE {id_field} IN {id_list}")
+        index = self._build_index(result['diaObjectId'],result['filterName'])
+        result.index = index
+        result = result[cols].sort_index()
+        self.table = result
+        return result
+
+    def to_timeseries(self,dataframe,target,core_cols=['midPointTai','psFlux','psFluxErr'],add_cols=[]):
+        cols = core_cols+add_cols
+        df = dataframe.xs(target)
+        ts = timeseries()._from_ensemble(data=df,object_id=target)
+        return ts
+
+    def _build_index(self,obj_id, band):
+        """Build pandas multiindex from object_ids and bands"""
+        #Create a multiindex
+
+        idx = range(len(list(zip(obj_id,band))))
+        tuples = zip(obj_id,band,idx)
+        index = pd.MultiIndex.from_tuples(tuples, names=["object_id","band", "index"])
+        return index
+

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -2,52 +2,96 @@ import pandas as pd
 
 
 class timeseries():
-    def __init__(self):
-        self.data = None
-        self.id = None
-        self.cols = ['time', 'flux', 'flux_err']
+    """represent and analyze Rubin timeseries data"""
+    def __init__(self, data=None):
+        self.data = data
+        self.meta = {'id': None} # metadata dict
+        self.colmap = {'time': None, 'flux': None, 'flux_err': None} # column mapping
 
     # I/O
-    def from_dict(self, data_dict, band_label='band'):
+    def from_dict(self, data_dict, time_label='time', flux_label='flux', err_label='flux_err', 
+                  band_label='band'):
         """Build dataframe from a python dictionary
 
         Parameters
         ----------
         data_dict : `dict`
             Dictionary contaning the data
+        time_label: `str`
+            Name for column containing time information
+        flux_label: `str`
+            Name for column containing signal (flux, magnitude, etc) information
+        err_label: `str`
+            Name for column containing error information
         band_label: `str`
-            Name for column contaning filter information
+            Name for column containing filter information
         """
+
+        try:
+            data_dict[band_label]
+        except KeyError:
+            raise KeyError(f"The indicated label '{band_label}' was not found.")
         index = self._build_index(data_dict[band_label])
         data_dict = {key: data_dict[key] for key in data_dict if key != band_label}
         self.data = pd.DataFrame(data=data_dict, index=index).sort_index()
-        return self
 
-    def _from_ensemble(self, data, object_id):
+        labels = [time_label, flux_label, err_label]
+        
+        for label, quantity in zip(labels, list(self.colmap.keys())):
+
+            if (quantity == 'flux_err') and (label is None): # flux_err is optional
+                continue
+
+            try:
+                self.data[label]
+                self.colmap[quantity] = label
+            except KeyError:
+                raise KeyError(f"The indicated label '{label}' was not found.")
+            
+        return self      
+
+    def _from_ensemble(self, data, object_id, time_label='time', flux_label='flux', err_label='flux_err'):
         """Loader function for inputing data from an ensemble"""
         self.cols = list(data.columns)
         self.data = data
-        self.id = object_id
+        self.meta['id'] = object_id
+
+        labels = [time_label, flux_label, err_label]
+        
+        for label, quantity in zip(labels, list(self.colmap.keys())):
+
+            if (quantity == 'flux_err') and (label is None): # flux_err is optional
+                continue
+
+            try:
+                self.data[label]
+                self.colmap[quantity] = label
+            except KeyError:
+                raise KeyError(f"The indicated label '{label}' was not found.")
+
         return self
 
     @property
     def time(self):
         """Time values stored as a Pandas Series"""
-        return self.data[self.cols[0]]
+        return self.data[self.colmap['time']]
 
     @property
     def flux(self):
         """Flux values stored as a Pandas Series"""
-        return self.data[self.cols[1]]
+        return self.data[self.colmap['flux']]
 
     @property
     def flux_err(self):
         """Flux error values stored as a Pandas Series"""
-        return self.data[self.cols[2]]
+        if self.colmap['flux_err'] is not None: # Errors are not mandatory
+            return self.data[self.colmap['flux_err']]
+        else:
+            return None
 
     @property
     def band(self):
-        """Band labels stored as a Pandas Series from Index"""
+        """Band labels stored as a Pandas Index"""
         return self.data.index.get_level_values('band')
 
     def _build_index(self, band):

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -5,6 +5,7 @@ class timeseries():
     def __init__(self):
         self.data = None
         self.id = None
+        self.cols = ['time','flux','flux_err']
     
     #I/O
     def from_dict(self,data_dict,band_label='band'):
@@ -15,24 +16,26 @@ class timeseries():
         return self
 
     def _from_ensemble(self, data,object_id):
+        """loader function for inputing data from an ensemble"""
+        self.cols = list(data.columns)
         self.data=data
         self.id=object_id
         return self
-    
+
     @property
     def time(self):
         """Time values stored as a Pandas Series"""
-        return self.data["time"]
+        return self.data[self.cols[0]]
     
     @property
     def flux(self):
         """Flux values stored as a Pandas Series"""
-        return self.data["flux"]
+        return self.data[self.cols[1]]
     
     @property
     def flux_err(self):
         """Flux error values stored as a Pandas Series"""
-        return self.data["flux_err"]
+        return self.data[self.cols[2]]
     
     @property
     def band(self):

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -1,50 +1,58 @@
 import pandas as pd
-import numpy as np
+
 
 class timeseries():
     def __init__(self):
         self.data = None
         self.id = None
-        self.cols = ['time','flux','flux_err']
-    
-    #I/O
-    def from_dict(self,data_dict,band_label='band'):
-        """Build dataframe from a python dictionary"""
+        self.cols = ['time', 'flux', 'flux_err']
+
+    # I/O
+    def from_dict(self, data_dict, band_label='band'):
+        """Build dataframe from a python dictionary
+
+        Parameters
+        ----------
+        data_dict : `dict`
+            Dictionary contaning the data
+        band_label: `str`
+            Name for column contaning filter information
+        """
         index = self._build_index(data_dict[band_label])
         data_dict = {key: data_dict[key] for key in data_dict if key != band_label}
-        self.data = pd.DataFrame(data=data_dict,index=index).sort_index()
+        self.data = pd.DataFrame(data=data_dict, index=index).sort_index()
         return self
 
-    def _from_ensemble(self, data,object_id):
-        """loader function for inputing data from an ensemble"""
+    def _from_ensemble(self, data, object_id):
+        """Loader function for inputing data from an ensemble"""
         self.cols = list(data.columns)
-        self.data=data
-        self.id=object_id
+        self.data = data
+        self.id = object_id
         return self
 
     @property
     def time(self):
         """Time values stored as a Pandas Series"""
         return self.data[self.cols[0]]
-    
+
     @property
     def flux(self):
         """Flux values stored as a Pandas Series"""
         return self.data[self.cols[1]]
-    
+
     @property
     def flux_err(self):
         """Flux error values stored as a Pandas Series"""
         return self.data[self.cols[2]]
-    
+
     @property
     def band(self):
         """Band labels stored as a Pandas Series from Index"""
         return self.data.index.get_level_values('band')
-    
-    def _build_index(self,band):
+
+    def _build_index(self, band):
         """Build pandas multiindex from band array"""
-        #Create a multiindex
-        tuples = zip(band,range(len(band)))
+        # Create a multiindex
+        tuples = zip(band, range(len(band)))
         index = pd.MultiIndex.from_tuples(tuples, names=["band", "index"])
         return index

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -2,8 +2,9 @@ import pandas as pd
 import numpy as np
 
 class timeseries():
-    def __init__(self,data=None):
-        self.data = data
+    def __init__(self):
+        self.data = None
+        self.id = None
     
     #I/O
     def from_dict(self,data_dict,band_label='band'):
@@ -11,6 +12,11 @@ class timeseries():
         index = self._build_index(data_dict[band_label])
         data_dict = {key: data_dict[key] for key in data_dict if key != band_label}
         self.data = pd.DataFrame(data=data_dict,index=index).sort_index()
+        return self
+
+    def _from_ensemble(self, data,object_id):
+        self.data=data
+        self.id=object_id
         return self
     
     @property


### PR DESCRIPTION
This PR includes a *rough* implementation of the ensemble class, which is the object that contains many lightcurves. This is distinct from the timeseries class, which holds the information of one lightcurve, indexed by band and an arbitrary integer index. The ensemble is essentially just one additional index level, based on an object id, which allows index slicing to return individual light curves.

The implementation here focuses on IO and particularly the use case of pulling data down from the TAP: https://data.lsst.cloud/api-aspect . A token is needed to query against TAP, the link explains how to generate one.

As I mention above, I think this implementation is somewhat rough. The initial challenge with trying to emulate a LightKurve like approach for lsstseries is that with TAP we are querying for multiple objects, rather than pulling down a single object via ID (a use case we will want to implement soon). The ADQL query space is huge, and so there's a trade-off between giving users the power to construct complex queries, and user friendliness.  I've attached a diagram of how the ensemble workflow currently functions for TAP. Note that realistically a user may query TAP several times in succession to get a final target list. The query_ids function exists to give a more constrained query that is formatted such that lightcurves can be pulled out of it.

This PR also builds out timeseries slightly, adding some handling for different column names and stored metadata.

![ensemble drawio (2)](https://user-images.githubusercontent.com/8853505/196465125-770a4e1e-79fd-4e64-8b5a-081ba2fee256.png)
