### PR TITLE
Smart Indexing & Analysis Submodule

### DIFF
--- a/lsstseries/__init__.py
+++ b/lsstseries/__init__.py
@@ -1,1 +1,3 @@
+from .analysis import *
 from .timeseries import *
+from .ensemble import *

--- a/lsstseries/analysis/__init__.py
+++ b/lsstseries/analysis/__init__.py
@@ -1,0 +1,1 @@
+from .stetsonj import *

--- a/lsstseries/analysis/stetsonj.py
+++ b/lsstseries/analysis/stetsonj.py
@@ -1,0 +1,139 @@
+import numpy as np
+
+def calc_stetson_J(flux, err, band, band_to_calc=None):
+    """Compute the stetsonJ statistic on data from one or several bands
+        Parameters
+        ----------
+        flux : `numpy.ndarray` (N,)
+            Array of flux/magnitude measurements
+        err : `numpy.ndarray` (N,)
+            Array of associated flux/magnitude errors
+        band : `numpy.ndarray` (N,)
+            Array of associated band labels
+        band_to_calc : `str` or `list` of `str`
+            Bands to calculate stetson J on. Single band descriptor, or list 
+            of such descriptors.
+        Returns
+        -------
+        stetsonJ : `dict`
+            StetsonJ statistic for each of input bands.
+        Notes
+        ----------
+        In case that no value for `band_to_calc` is passed, the function is 
+        executed on all available bands in `band`.
+        """
+
+    unq_band = np.unique(band)
+
+    if band_to_calc is None:
+        band_to_calc = unq_band
+    if isinstance(band_to_calc,str):
+        band_to_calc = [band_to_calc]
+
+    assert hasattr(band_to_calc, '__iter__') is True
+
+    StetsonJ = {}
+    # TODO: ability to remove nan values
+    for b in band_to_calc:
+        if b in unq_band:
+            mask = band == b
+            fluxes = flux[mask]
+            errors = err[mask]
+            StetsonJ[b] = _stetson_J_single(fluxes, errors)
+        else:
+            StetsonJ[b] = np.nan
+
+    return StetsonJ
+
+def _stetson_J_single(fluxes, errors):
+    """Compute the single band stetsonJ statistic.
+    Parameters
+    ----------
+    fluxes : `numpy.ndarray` (N,)
+        Lightcurve flux values.
+    errors : `numpy.ndarray` (N,)
+        Errors on the lightcurve fluxes.
+    Returns
+    -------
+    stetsonJ : `float`
+        StetsonJ statistic
+    References
+    ----------
+    .. [1] Stetson, P. B., "On the Automatic Determination of Light-Curve
+    Parameters for Cepheid Variables", PASP, 108, 851S, 1996
+    Notes
+    ----------
+    Taken from
+    https://github.com/lsst/meas_base/blob/main/python/lsst/meas/base/diaCalculationPlugins.py
+    Using the function on random gaussian distribution gives result of -0.2
+    instead of expected result of 0?
+    """
+    mean = None
+    n_points = len(fluxes)
+    if n_points <= 1:
+        return np.nan
+    flux_mean = _stetson_mean(fluxes, errors, mean)
+    delta_val = (
+        np.sqrt(n_points / (n_points - 1)) * (fluxes - flux_mean) / errors)
+    p_k = delta_val ** 2 - 1
+    return np.mean(np.sign(p_k) * np.sqrt(np.fabs(p_k)))
+
+def _stetson_mean(values,
+                  errors,
+                  mean=None,
+                  alpha=2.,
+                  beta=2.,
+                  n_iter=20,
+                  tol=1e-6):
+    """Compute the stetson mean of the fluxes which down-weights outliers.
+    Weighted biased on an error weighted difference scaled by a constant
+    (1/``a``) and raised to the power beta. Higher betas more harshly
+    penalize outliers and ``a`` sets the number of sigma where a weighted
+    difference of 1 occurs.
+    Parameters
+    ----------
+    values : `numpy.dnarray`, (N,)
+        Input values to compute the mean of.
+    errors : `numpy.ndarray`, (N,)
+        Errors on the input values.
+    mean : `float`
+        Starting mean value or None.
+    alpha : `float`
+        Scalar down-weighting of the fractional difference. lower->more
+        clipping. (Default value is 2.)
+    beta : `float`
+        Power law slope of the used to down-weight outliers. higher->more
+        clipping. (Default value is 2.)
+    n_iter : `int`
+        Number of iterations of clipping.
+    tol : `float`
+        Fractional and absolute tolerance goal on the change in the mean
+        before exiting early. (Default value is 1e-6)
+    Returns
+    -------
+    mean : `float`
+        Weighted stetson mean result.
+    References
+    ----------
+    .. [1] Stetson, P. B., "On the Automatic Determination of Light-Curve
+    Parameters for Cepheid Variables", PASP, 108, 851S, 1996
+    Notes
+    ----------
+    Taken from
+    https://github.com/lsst/meas_base/blob/main/python/lsst/meas/base/diaCalculationPlugins.py
+    """
+    n_points = len(values)
+    n_factor = np.sqrt(n_points / (n_points - 1))
+    inv_var = 1 / errors ** 2
+    if mean is None:
+        mean = np.average(values, weights=inv_var)
+    for iter_idx in range(n_iter):
+        chi = np.fabs(n_factor * (values - mean) / errors)
+        tmp_mean = np.average(
+            values,
+            weights=inv_var / (1 + (chi / alpha) ** beta))
+        diff = np.fabs(tmp_mean - mean)
+        mean = tmp_mean
+        if diff / mean < tol and diff < tol:
+            break
+    return mean

--- a/lsstseries/ensemble.py
+++ b/lsstseries/ensemble.py
@@ -210,7 +210,7 @@ class ensemble():
         count_dict = {}
         idx = []
         for o, b in zip(obj_id,band):
-            if f"{o},{b}" in count_dict.keys():
+            if f"{o},{b}" in count_dict:
                 idx.append(count_dict[f"{o},{b}"])
                 count_dict[f"{o},{b}"]+=1
             else:

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import numpy as np
+from lsstseries.analysis.stetsonj import calc_stetson_J
 
 
 class timeseries():
@@ -69,10 +69,14 @@ class timeseries():
         return self
 
 
-    def _from_ensemble(self, data, object_id, time_label='time', flux_label='flux', err_label='flux_err'):
+    def _from_ensemble(self, data, object_id, time_label='time', flux_label='flux',
+                       err_label='flux_err', band_label = 'band'):
         """Loader function for inputing data from an ensemble"""
         self.data = data
         self.meta['id'] = object_id
+
+        index = self._build_index(self.data[band_label])
+        self.data.index = index
 
         labels = [time_label, flux_label, err_label]
         for label, quantity in zip(labels, list(self.colmap.keys())):
@@ -132,132 +136,7 @@ class timeseries():
         Notes
         ----------
         In case that no value for band is passed, the function is executed
-        on all avaliable bands.
+        on all available bands.
         """
-        unq_band = np.unique(self.band)
-
-        if band is None:
-            band = unq_band
-        if type(band) == str:
-            band = [band]
-
-        assert hasattr(band, '__iter__') is True
-
-        StetsonJ = {}
-        # TODO: ability to remove nan values
-        for b in band:
-            if b in unq_band:
-                fluxes = self.flux[b].values
-                errors = self.flux_err[b].values
-                StetsonJ[b] = self._stetson_J_single(fluxes, errors)
-            else:
-                StetsonJ[b] = np.nan
-        return StetsonJ
-
-    def _stetson_J_single(self, fluxes, errors):
-        """Compute the single band stetsonJ statistic.
-
-        Parameters
-        ----------
-        fluxes : `numpy.ndarray` (N,)
-            Lightcurve flux values.
-        errors : `numpy.ndarray` (N,)
-            Errors on the lightcurve fluxes.
-
-        Returns
-        -------
-        stetsonJ : `float`
-            StetsonJ statistic
-
-        References
-        ----------
-        .. [1] Stetson, P. B., "On the Automatic Determination of Light-Curve
-        Parameters for Cepheid Variables", PASP, 108, 851S, 1996
-
-        Notes
-        ----------
-        Taken from
-        https://github.com/lsst/meas_base/blob/main/python/lsst/meas/base/diaCalculationPlugins.py
-
-        Using the function on random gaussian distribution gives result of -0.2
-        instead of expected result of 0?
-        """
-        mean = None
-
-        n_points = len(fluxes)
-        if n_points <= 1:
-            return np.nan
-
-        flux_mean = self._stetson_mean(fluxes, errors, mean)
-        delta_val = (
-            np.sqrt(n_points / (n_points - 1)) * (fluxes - flux_mean) / errors)
-        p_k = delta_val ** 2 - 1
-
-        return np.mean(np.sign(p_k) * np.sqrt(np.fabs(p_k)))
-
-    def _stetson_mean(self,
-                      values,
-                      errors,
-                      mean=None,
-                      alpha=2.,
-                      beta=2.,
-                      n_iter=20,
-                      tol=1e-6):
-        """Compute the stetson mean of the fluxes which down-weights outliers.
-
-        Weighted biased on an error weighted difference scaled by a constant
-        (1/``a``) and raised to the power beta. Higher betas more harshly
-        penalize outliers and ``a`` sets the number of sigma where a weighted
-        difference of 1 occurs.
-
-        Parameters
-        ----------
-        values : `numpy.dnarray`, (N,)
-            Input values to compute the mean of.
-        errors : `numpy.ndarray`, (N,)
-            Errors on the input values.
-        mean : `float`
-            Starting mean value or None.
-        alpha : `float`
-            Scalar down-weighting of the fractional difference. lower->more
-            clipping. (Default value is 2.)
-        beta : `float`
-            Power law slope of the used to down-weight outliers. higher->more
-            clipping. (Default value is 2.)
-        n_iter : `int`
-            Number of iterations of clipping.
-        tol : `float`
-            Fractional and absolute tolerance goal on the change in the mean
-            before exiting early. (Default value is 1e-6)
-
-        Returns
-        -------
-        mean : `float`
-            Weighted stetson mean result.
-
-        References
-        ----------
-        .. [1] Stetson, P. B., "On the Automatic Determination of Light-Curve
-        Parameters for Cepheid Variables", PASP, 108, 851S, 1996
-
-        Notes
-        ----------
-        Taken from
-        https://github.com/lsst/meas_base/blob/main/python/lsst/meas/base/diaCalculationPlugins.py
-        """
-        n_points = len(values)
-        n_factor = np.sqrt(n_points / (n_points - 1))
-        inv_var = 1 / errors ** 2
-
-        if mean is None:
-            mean = np.average(values, weights=inv_var)
-        for iter_idx in range(n_iter):
-            chi = np.fabs(n_factor * (values - mean) / errors)
-            tmp_mean = np.average(
-                values,
-                weights=inv_var / (1 + (chi / alpha) ** beta))
-            diff = np.fabs(tmp_mean - mean)
-            mean = tmp_mean
-            if diff / mean < tol and diff < tol:
-                break
-        return mean
+        return calc_stetson_J(self.flux, self.flux_err, self.band,
+                              band_to_calc=band)

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -50,22 +50,9 @@ class timeseries():
 
         return self
 
-    def handle_nans(self, strategy='remove'):
-        """Clean the input dataset of NaN values
-
-        Parameters
-        ----------
-        strategy : `str`
-            strategy to handle NaNs
-        """
-
-        if strategy =='remove':
-            self.data = self.data.dropna()
-        elif strategy == 'interpolate':
-            raise NotImplementedError
-        else:
-            raise ValueError("Provided strategy not recognized")
-
+    def dropna(self, **kwargs):
+        """Handle NaN values, wrapper for pandas.DataFrame.dropna"""
+        self.data = self.data.dropna(**kwargs)
         return self
 
 

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -50,6 +50,25 @@ class timeseries():
 
         return self
 
+    def handle_nans(self, strategy='remove'):
+        """Clean the input dataset of NaN values
+
+        Parameters
+        ----------
+        strategy : `str`
+            strategy to handle NaNs
+        """
+
+        if strategy =='remove':
+            self.data = self.data.dropna()
+        elif strategy == 'interpolate':
+            raise NotImplementedError
+        else:
+            raise ValueError("Provided strategy not recognized")
+
+        return self
+
+
     def _from_ensemble(self, data, object_id, time_label='time', flux_label='flux', err_label='flux_err'):
         """Loader function for inputing data from an ensemble"""
         self.data = data

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -103,7 +103,19 @@ class timeseries():
     def _build_index(self, band):
         """Build pandas multiindex from band array"""
         # Create a multiindex
-        tuples = zip(band, range(len(band)))
+        idx = range(len(band))
+
+        #idx to count up for each unique pair of obj_id,band 
+        count_dict = {}
+        idx = []
+        for b in band:
+            if f"{b}" in count_dict:
+                idx.append(count_dict[f"{b}"])
+                count_dict[f"{b}"]+=1
+            else:
+                idx.append(0)
+                count_dict[f"{b}"]=1
+        tuples = zip(band, idx)
         index = pd.MultiIndex.from_tuples(tuples, names=["band", "index"])
         return index
 


### PR DESCRIPTION
This PR addresses two issues: #10 and #11 

Adds smart indexing; the lowest level index is an integer counting the nth row for each unique (id, band) pair. Previously the lowest level index just counted per row, without association to object id or band.

Adds an analysis submodule, and moves the stetsonJ function out of timeseries.py and into the submodule. This will enable groupby->apply style calls to these functions from the ensemble, which is a blocker for testing dask and vaex at scale.

A simple wrapper function for pandas.DataFrame.dropna was also added, but this will almost certainly be clobbered by whichever refactor route we go so I wouldn't spend too much time on it.