### PR TITLE
First Set of Structure Function Enhancements

### DIFF
--- a/lsstseries/analysis/structurefunction2.py
+++ b/lsstseries/analysis/structurefunction2.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 
 
-def calc_sf2(lc_id, time, flux, err, band,
+def calc_sf2(lc_id, time, flux, err, band, bins=None,
              band_to_calc=None, combine=False, method='size', sthresh=100):
     """Compute structure function squared on one or many bands
 
@@ -19,6 +19,9 @@ def calc_sf2(lc_id, time, flux, err, band,
         Array of associated flux/magnitude errors.
     band : `numpy.ndarray` (N,)
         Array of associated band labels,
+    bins : `numpy.ndarray`
+        Manually provided bins, if not provided then bins are computed using
+        the `method` kwarg
     band_to_calc : `str` or `list` of `str`
         Bands to calculate structure function on. Single band descriptor,
         or list of such descriptors.
@@ -75,8 +78,8 @@ def calc_sf2(lc_id, time, flux, err, band,
             fluxes_2d = [fluxes[mask] for mask in id_masks]
             errors_2d = [errors[mask] for mask in id_masks]
 
-            res = _sf2_single(times_2d, fluxes_2d, errors_2d, combine=combine,
-                              method=method, sthresh=sthresh)
+            res = _sf2_single(times_2d, fluxes_2d, errors_2d, bins=bins,
+                              combine=combine, method=method, sthresh=sthresh)
 
             res_ids = [[str(unq_ids[i])]*len(arr) for i, arr in enumerate(res[0])]
             res_bands = [[b]*len(arr) for arr in res[0]]
@@ -95,7 +98,7 @@ def calc_sf2(lc_id, time, flux, err, band,
     return sf2_df
 
 
-def _sf2_single(times, fluxes, errors,
+def _sf2_single(times, fluxes, errors, bins=None,
                 combine=False, method='size', sthresh=100):
     """Calculate structure function squared
 
@@ -105,12 +108,15 @@ def _sf2_single(times, fluxes, errors,
 
     Parameters
     ----------
-    time : `np.array` [`float`]
+    times : `np.array` [`float`]
         Times at which the measurements were conducted.
-    y : `np.array` [`float`]
+    fluxes : `np.array` [`float`]
         Measurements values
-    yerr : `np.array` [`float`]
+    errors : `np.array` [`float`]
         Measurements errors.
+    bins : `np.array` [`float`]
+        Manually provided bins, if not provided then bins are computed using
+        the `method` kwarg
     combine : 'bool'
         Boolean to determine whether structure function is computed for each
         light curve independently (combine=False), or computed for all light
@@ -184,7 +190,8 @@ def _sf2_single(times, fluxes, errors,
         cor_flux2_all = np.hstack(np.array(cor_flux2_all, dtype='object'))
 
         # binning
-        bins = _bin_dts(d_times_all, method=method, sthresh=sthresh)
+        if bins is None:
+            bins = _bin_dts(d_times_all, method=method, sthresh=sthresh)
 
         # structure function at specific dt
         # the line below will throw error if the bins are not covering the whole range

--- a/lsstseries/analysis/structurefunction2.py
+++ b/lsstseries/analysis/structurefunction2.py
@@ -143,6 +143,16 @@ def _sf2_single(times, fluxes, errors,
         lc_fluxes = fluxes[lc_idx]
         lc_errors = errors[lc_idx]
 
+        # mask out any nan values
+        t_mask = np.isnan(lc_times)
+        f_mask = np.isnan(lc_fluxes)
+        e_mask = np.isnan(lc_errors)  # always mask out nan errors?
+        lc_mask = np.logical_or(t_mask, f_mask, e_mask)
+
+        lc_times = lc_times[~lc_mask]
+        lc_fluxes = lc_fluxes[~lc_mask]
+        lc_errors = lc_errors[~lc_mask]
+
         # compute d_times (difference of times) and
         # d_fluxes (difference of magnitudes, i.e., fluxes) for all gaps
         # d_times - difference of times

--- a/lsstseries/ensemble.py
+++ b/lsstseries/ensemble.py
@@ -111,9 +111,9 @@ class ensemble:
         func : `function`
             A function to apply to all objects in the ensemble
         meta : `pd.Series`, `pd.DataFrame`, `dict`, or `tuple-like`
-            Dask's meta parameter, which lays down the expected structure of 
+            Dask's meta parameter, which lays down the expected structure of
             the results. Overridden by lsstseries for lsstseries
-            functions. If none, attempts to coerce the result to a 
+            functions. If none, attempts to coerce the result to a
             pandas.series.
         *args:
             Denotes the ensemble columns to use as inputs for a function,

--- a/lsstseries/ensemble.py
+++ b/lsstseries/ensemble.py
@@ -3,6 +3,7 @@ import dask.dataframe as dd
 from dask.distributed import Client
 import pyvo as vo
 from .timeseries import timeseries
+from .analysis.structurefunction2 import calc_sf2
 import time
 
 
@@ -102,7 +103,7 @@ class ensemble:
         self.data = self.data[self.data[col_name] >= threshold]
         return self
 
-    def batch(self, func, *args, **kwargs):
+    def batch(self, func, meta=None, *args, **kwargs):
         """Run a function from lsstseries.timeseries on the available ids
 
         Parameters
@@ -128,13 +129,25 @@ class ensemble:
         ensemble.batch(calc_stetson_J, band_to_calc='i')
         `
         """
-        known_cols = {'calc_stetson_J': [self._flux_col, self._err_col, self._band_col]}
+        known_cols = {'calc_stetson_J': [self._flux_col, self._err_col, self._band_col],
+                      'calc_sf2': [self._id_col, self._time_col, self._flux_col,
+                                   self._err_col, self._band_col]}
+
+        known_meta = {'calc_sf2': {'lc_id': 'int', 'band': 'str', 'dt': 'float', 'sf2': 'float'}}
         if func.__name__ in known_cols:
             args = known_cols[func.__name__]
+        if func.__name__ in known_meta:
+            meta = known_meta[func.__name__]
 
-        batch = self.data.groupby(self._id_col).apply(lambda x: func(*[x[arg] for arg in args],
-                                                                     **kwargs),
-                                                      meta=(self._id_col, type(self._id_col)))
+        if meta is None:
+            meta = (self._id_col, type(self._id_col))  # return a series of ids
+
+        id_col = self._id_col  # pre-compute needed for dask in lambda function
+
+        batch = self.data.groupby(self._id_col).apply(lambda x: func(*[x[arg]
+                                                      if arg != id_col else x.index
+                                                      for arg in args], **kwargs),
+                                                      meta=meta)
 
         result = batch.compute()
         return result
@@ -434,3 +447,47 @@ class ensemble:
         tuples = zip(obj_id, band, idx)
         index = pd.MultiIndex.from_tuples(tuples, names=["object_id", "band", "index"])
         return index
+
+    def sf2(self, band_to_calc=None, combine=False,
+            method="size", sthresh=100):
+        """Wrapper interface for calling structurefunction2 on the ensemble
+
+        Parameters
+        ----------
+        band_to_calc : `str` or `list` of `str`
+            Bands to calculate structure function on. Single band descriptor,
+            or list of such descriptors.
+        combine : 'bool'
+            Boolean to determine whether structure function is computed for each
+            light curve independently (combine=False), or computed for all light
+            curves together (combine=True).
+        method : 'str'
+            The binning method to apply, choices of 'size'; which seeks an even
+            distribution of samples per bin using quantiles, 'length'; which
+            creates bins of equal length in time and 'loglength'; which creates
+            bins of equal length in log time.
+        sthresh : 'int'
+            Target number of samples per bin.
+
+        Returns
+        ----------
+        result : `pandas.DataFrame`
+            Structure function squared for each of input bands.
+
+        Notes
+        ----------
+        In case that no value for `band_to_calc` is passed, the function is
+        executed on all available bands in `band`.
+        """
+
+        if combine:
+            result = calc_sf2(self.data.index, self.data[self._time_col],
+                              self.data[self._flux_col], self.data[self._err_col],
+                              self.data[self._band_col], band_to_calc=band_to_calc,
+                              combine=combine, method=method, sthresh=sthresh)
+            return result
+        else:
+            result = self.batch(calc_sf2, band_to_calc=band_to_calc, combine=False,
+                                method=method, sthresh=sthresh)
+
+            return result

--- a/lsstseries/ensemble.py
+++ b/lsstseries/ensemble.py
@@ -110,6 +110,11 @@ class ensemble:
         ----------
         func : `function`
             A function to apply to all objects in the ensemble
+        meta : `pd.Series`, `pd.DataFrame`, `dict`, or `tuple-like`
+            Dask's meta parameter, which lays down the expected structure of 
+            the results. Overridden by lsstseries for lsstseries
+            functions. If none, attempts to coerce the result to a 
+            pandas.series.
         *args:
             Denotes the ensemble columns to use as inputs for a function,
             order must be correct for function. If passing a lsstseries

--- a/lsstseries/ensemble.py
+++ b/lsstseries/ensemble.py
@@ -453,12 +453,15 @@ class ensemble:
         index = pd.MultiIndex.from_tuples(tuples, names=["object_id", "band", "index"])
         return index
 
-    def sf2(self, band_to_calc=None, combine=False,
+    def sf2(self, bins=None, band_to_calc=None, combine=False,
             method="size", sthresh=100):
         """Wrapper interface for calling structurefunction2 on the ensemble
 
         Parameters
         ----------
+        bins : `np.array` or `list`
+        Manually provided bins, if not provided then bins are computed using
+        the `method` kwarg
         band_to_calc : `str` or `list` of `str`
             Bands to calculate structure function on. Single band descriptor,
             or list of such descriptors.
@@ -488,11 +491,11 @@ class ensemble:
         if combine:
             result = calc_sf2(self.data.index, self.data[self._time_col],
                               self.data[self._flux_col], self.data[self._err_col],
-                              self.data[self._band_col], band_to_calc=band_to_calc,
+                              self.data[self._band_col], bins=bins, band_to_calc=band_to_calc,
                               combine=combine, method=method, sthresh=sthresh)
             return result
         else:
-            result = self.batch(calc_sf2, band_to_calc=band_to_calc, combine=False,
+            result = self.batch(calc_sf2, bins=bins, band_to_calc=band_to_calc, combine=False,
                                 method=method, sthresh=sthresh)
 
             return result

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -144,16 +144,20 @@ class timeseries:
         """
         return calc_stetson_J(self.flux, self.flux_err, self.band, band_to_calc=band)
 
-    def sf2(self, bins=None, band=None):
+    def sf2(self, band=None, method='size', sthresh=100):
         """Compute the structure function squared statistic on data
 
         Parameters
         ----------
-        bins : `np.array`
-            Times defining edges of time bins in which to compute
-            structure function
         band : `str` or `list` of `str`
             Single band descriptor, or list of such descriptors.
+        method : 'str'
+            The binning method to apply, choices of 'size'; which seeks an even
+            distribution of samples per bin using quantiles, 'length'; which
+            creates bins of equal length in time and 'loglength'; which creates
+            bins of equal length in log time.
+        sthresh : 'int'
+            Target number of samples per bin.
 
         Returns
         -------
@@ -165,4 +169,6 @@ class timeseries:
         In case that no value for band is passed, the function is executed
         on all available bands.
         """
-        return calc_sf2(self.time, self.flux, self.flux_err, bins, self.band, band_to_calc=band)
+        lc_id = [self.meta['id']]*len(self.time)
+        return calc_sf2(lc_id, self.time, self.flux, self.flux_err, self.band,
+                        band_to_calc=band, method=method, sthresh=sthresh)

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -144,11 +144,14 @@ class timeseries:
         """
         return calc_stetson_J(self.flux, self.flux_err, self.band, band_to_calc=band)
 
-    def sf2(self, band_to_calc=None, method='size', sthresh=100):
+    def sf2(self, bins=None, band_to_calc=None, method='size', sthresh=100):
         """Compute the structure function squared statistic on data
 
         Parameters
         ----------
+        bins : `numpy.array` or `list`
+        Manually provided bins, if not provided then bins are computed using
+        the `method` kwarg
         band_to_calc : `str` or `list` of `str`
             Single band descriptor, or list of such descriptors.
         method : 'str'
@@ -169,6 +172,9 @@ class timeseries:
         In case that no value for band_to_calc is passed, the function is executed
         on all available bands.
         """
-        lc_id = [self.meta['id']]*len(self.time)
-        return calc_sf2(lc_id, self.time, self.flux, self.flux_err, self.band,
+        if self.meta['id']:
+            lc_id = [self.meta['id']]*len(self.time)
+        else:
+            lc_id = [0]*len(self.time)
+        return calc_sf2(lc_id, self.time, self.flux, self.flux_err, self.band, bins=bins,
                         band_to_calc=band_to_calc, method=method, sthresh=sthresh, combine=False)

--- a/lsstseries/timeseries.py
+++ b/lsstseries/timeseries.py
@@ -144,12 +144,12 @@ class timeseries:
         """
         return calc_stetson_J(self.flux, self.flux_err, self.band, band_to_calc=band)
 
-    def sf2(self, band=None, method='size', sthresh=100):
+    def sf2(self, band_to_calc=None, method='size', sthresh=100):
         """Compute the structure function squared statistic on data
 
         Parameters
         ----------
-        band : `str` or `list` of `str`
+        band_to_calc : `str` or `list` of `str`
             Single band descriptor, or list of such descriptors.
         method : 'str'
             The binning method to apply, choices of 'size'; which seeks an even
@@ -166,9 +166,9 @@ class timeseries:
 
         Notes
         ----------
-        In case that no value for band is passed, the function is executed
+        In case that no value for band_to_calc is passed, the function is executed
         on all available bands.
         """
         lc_id = [self.meta['id']]*len(self.time)
         return calc_sf2(lc_id, self.time, self.flux, self.flux_err, self.band,
-                        band_to_calc=band, method=method, sthresh=sthresh)
+                        band_to_calc=band_to_calc, method=method, sthresh=sthresh, combine=False)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,6 +1,7 @@
 """Test timeseries analysis functions"""
 
 from lsstseries import timeseries
+import pytest
 
 
 def test_stetsonj():
@@ -21,7 +22,7 @@ def test_stetsonj():
     assert test_ts.stetson_J()["r"] == 0.8
 
 
-def test_sf2():
+def test_sf2_from_timeseries():
     """
     Test of structure function squared function for a known return value
     """
@@ -29,7 +30,6 @@ def test_sf2():
     test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
     test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
     test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
-    test_bins = [1, 3, 5, 7]
 
     test_dict = {
         "time": test_t,
@@ -38,8 +38,9 @@ def test_sf2():
         "band": ["r"] * len(test_y),
     }
     ts = timeseries()
+    ts.meta['id'] = 1
     test_ts = ts.from_dict(data_dict=test_dict)
-    res = test_ts.sf2(bins=test_bins)["r"]
+    res = test_ts.sf2(sthresh=100)
 
-    print("test sf2 value is: " + str(res))
-    assert sum(res[1]) == -0.0126072883605957
+    assert res['dt'][0] == pytest.approx(3.705, rel=0.001)
+    assert res['sf2'][0] == pytest.approx(0.005365, rel=0.001)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -48,6 +48,9 @@ def test_sf2_timeseries():
 
 
 def test_dt_bins():
+    """
+    Test that the binning routines return the expected properties
+    """
     np.random.seed(1)
     dts = np.random.random_sample(1000)*5 + np.logspace(1, 2, 1000)
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -23,7 +23,8 @@ def test_stetsonj():
     assert test_ts.stetson_J()["r"] == 0.8
 
 
-def test_sf2_timeseries():
+@pytest.mark.parametrize("lc_id", [None, 1])
+def test_sf2_timeseries(lc_id):
     """
     Test of structure function squared function for a known return value
     """
@@ -39,7 +40,7 @@ def test_sf2_timeseries():
         "band": ["r"] * len(test_y),
     }
     ts = timeseries()
-    ts.meta['id'] = 1
+    ts.meta['id'] = lc_id
     test_ts = ts.from_dict(data_dict=test_dict)
     res = test_ts.sf2(sthresh=100)
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,8 @@
 """Test timeseries analysis functions"""
 
-from lsstseries import timeseries
+from lsstseries import timeseries, analysis
 import pytest
+import numpy as np
 
 
 def test_stetsonj():
@@ -22,7 +23,7 @@ def test_stetsonj():
     assert test_ts.stetson_J()["r"] == 0.8
 
 
-def test_sf2_from_timeseries():
+def test_sf2_timeseries():
     """
     Test of structure function squared function for a known return value
     """
@@ -44,3 +45,21 @@ def test_sf2_from_timeseries():
 
     assert res['dt'][0] == pytest.approx(3.705, rel=0.001)
     assert res['sf2'][0] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_dt_bins():
+    np.random.seed(1)
+    dts = np.random.random_sample(1000)*5 + np.logspace(1, 2, 1000)
+
+    # test size method
+    bins = analysis.structurefunction2._bin_dts(dts, method="size")
+    binsizes = np.histogram(dts, bins=bins)[0]
+    assert len(bins) == 11
+    assert len(np.unique(binsizes)) == 1  # Check that all bins are the same size
+
+    # test length method
+    bins = analysis.structurefunction2._bin_dts(dts, method="length")
+    assert len(bins) == 11
+
+    bins = analysis.structurefunction2._bin_dts(dts, method="loglength")
+    assert len(bins) == 11

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -8,7 +8,7 @@ from lsstseries.analysis.structurefunction2 import calc_sf2
 @pytest.fixture
 def parquet_data():
     ens = ensemble()
-    ens.from_parquet("data/test_subset.parquet", id_col='ps1_objid', band_col='filterName',
+    ens.from_parquet("tests/data/test_subset.parquet", id_col='ps1_objid', band_col='filterName',
                      flux_col='psFlux', err_col='psFluxErr')
 
     return ens

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -2,12 +2,13 @@
 import pytest
 from lsstseries import ensemble
 from lsstseries.analysis.stetsonj import calc_stetson_J
+from lsstseries.analysis.structurefunction2 import calc_sf2
 
 
 @pytest.fixture
 def parquet_data():
     ens = ensemble()
-    ens.from_parquet("tests/data/test_subset.parquet", id_col='ps1_objid', band_col='filterName',
+    ens.from_parquet("data/test_subset.parquet", id_col='ps1_objid', band_col='filterName',
                      flux_col='psFlux', err_col='psFluxErr')
 
     return ens
@@ -79,3 +80,22 @@ def test_build_index():
     result = list(ens._build_index(obj_ids, bands).get_level_values(2))
     target = [0, 1, 2, 0, 0, 0, 1]
     assert result == target
+
+
+@pytest.mark.parametrize("method", ["size", "length", "loglength"])
+@pytest.mark.parametrize("combine", [True, False])
+@pytest.mark.parametrize("sthresh", [50, 100])
+def test_sf2(parquet_data, method, combine, sthresh):
+    """
+    Test calling sf2 from the ensemble
+    """
+
+    ens = parquet_data
+
+    res_sf2 = ens.sf2(combine=combine, method=method, sthresh=sthresh)
+    res_batch = ens.batch(calc_sf2, combine=combine, method=method, sthresh=sthresh)
+
+    if combine:
+        assert not res_sf2.equals(res_batch)  # output should be different
+    else:
+        assert res_sf2.equals(res_batch)  # output should be identical


### PR DESCRIPTION
This PR is the first set of enhancements to the structurefunction2 implementation in lsstseries. This addresses some of the requirements listed in #22 and #23, but I wanted to check in at this stage to make sure everything is on the right track.

What's in this PR:
* Ability to operate on many lightcurves, either independently in batch mode, or with combination to have multiple lightcurves contribute to the same result
* Some nan filtering, to make sf2 runnable in ensembles that have not had nans handled
* Improved output, a pandas dataframe is now returned. ensemble.batch has been improved to allow the dask meta keyword (which defines the output structure) to be passed, but also provides a baked-in solution for calc_sf2.
* Automated binning, implemented 3 options. "size" solves for bins of roughly equal size (number of dts in said bin), "length" provides bins of equal length, and "loglength" provides bin of equal length in log-space.

What remains to be done once this PR is merged in:
* Error estimates via bootstrapping
* sampling methods for multi-light curve case (when combine=True)
* Data point combination (in same night, etc.)
* filtering steps for the light curves