### PR TITLE
Teardown ens dask client to fix #28

### DIFF
--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -11,7 +11,8 @@ def parquet_data():
     ens.from_parquet("tests/data/test_subset.parquet", id_col='ps1_objid', band_col='filterName',
                      flux_col='psFlux', err_col='psFluxErr')
 
-    return ens
+    yield ens
+    ens.client.close()
 
 
 def test_from_parquet(parquet_data):

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -81,6 +81,7 @@ def test_build_index():
     result = list(ens._build_index(obj_ids, bands).get_level_values(2))
     target = [0, 1, 2, 0, 0, 0, 1]
     assert result == target
+    ens.client.close()
 
 
 @pytest.mark.parametrize("method", ["size", "length", "loglength"])


### PR DESCRIPTION
Change the `parquet_data` fixture to stop the client in the ensemble made in the fixture after the test runs.