### PR TITLE
Inject dask client into ensemble

### DIFF
--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -12,6 +12,8 @@ from .timeseries import timeseries
 class ensemble:
     """ensemble object is a collection of light curve ids"""
 
+    client = None
+
     def __init__(self, token=None, client=None, **kwargs):
         self.result = None  # holds the latest query
         self.token = token
@@ -27,8 +29,16 @@ class ensemble:
         # Setup Dask Distributed Client
         if client:
             self.client = client
-        else:
+        elif not self.client:
             self.client = Client(**kwargs)  # arguments passed along to Client
+
+    def __enter__(self):
+        self.client = Client()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.client.close()
+        return self
 
     def client_info(self):
         """Calls the Dask Client, which returns cluster information

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -12,20 +12,23 @@ from .timeseries import timeseries
 class ensemble:
     """ensemble object is a collection of light curve ids"""
 
-    def __init__(self, token=None, **kwargs):
+    def __init__(self, token=None, client=None, **kwargs):
         self.result = None  # holds the latest query
         self.token = token
         self.data = None
 
         # Assign Default Values for critical column quantities
-        self._id_col = 'object_id'
-        self._time_col = 'midPointTai'
-        self._flux_col = 'psFlux'
-        self._err_col = 'psFluxErr'
-        self._band_col = 'band'
+        self._id_col = "object_id"
+        self._time_col = "midPointTai"
+        self._flux_col = "psFlux"
+        self._err_col = "psFluxErr"
+        self._band_col = "band"
 
         # Setup Dask Distributed Client
-        self.client = Client(**kwargs)  # arguments passed along to Client
+        if client:
+            self.client = client
+        else:
+            self.client = Client(**kwargs)  # arguments passed along to Client
 
     def client_info(self):
         """Calls the Dask Client, which returns cluster information
@@ -81,7 +84,7 @@ class ensemble:
         self.data = self.data[self.data.isnull().sum(axis=1) < threshold]
         return self
 
-    def prune(self, threshold=50, col_name='num_obs'):
+    def prune(self, threshold=50, col_name="num_obs"):
         """remove objects with less observations than a given threshold
 
         Parameters
@@ -101,7 +104,7 @@ class ensemble:
         if col_name not in self.data.columns:
             counts = self.data.groupby(self._id_col).count()
             counts = counts.rename(columns={self._time_col: col_name})[[col_name]]
-            self.data = self.data.join(counts, how='left')
+            self.data = self.data.join(counts, how="left")
         self.data = self.data[self.data[col_name] >= threshold]
         return self
 
@@ -136,11 +139,20 @@ class ensemble:
         ensemble.batch(calc_stetson_J, band_to_calc='i')
         `
         """
-        known_cols = {'calc_stetson_J': [self._flux_col, self._err_col, self._band_col],
-                      'calc_sf2': [self._id_col, self._time_col, self._flux_col,
-                                   self._err_col, self._band_col]}
+        known_cols = {
+            "calc_stetson_J": [self._flux_col, self._err_col, self._band_col],
+            "calc_sf2": [
+                self._id_col,
+                self._time_col,
+                self._flux_col,
+                self._err_col,
+                self._band_col,
+            ],
+        }
 
-        known_meta = {'calc_sf2': {'lc_id': 'int', 'band': 'str', 'dt': 'float', 'sf2': 'float'}}
+        known_meta = {
+            "calc_sf2": {"lc_id": "int", "band": "str", "dt": "float", "sf2": "float"}
+        }
         if func.__name__ in known_cols:
             args = known_cols[func.__name__]
         if func.__name__ in known_meta:
@@ -151,18 +163,29 @@ class ensemble:
 
         id_col = self._id_col  # pre-compute needed for dask in lambda function
 
-        batch = self.data.groupby(self._id_col).apply(lambda x: func(*[x[arg]
-                                                      if arg != id_col else x.index
-                                                      for arg in args], **kwargs),
-                                                      meta=meta)
+        batch = self.data.groupby(self._id_col).apply(
+            lambda x: func(
+                *[x[arg] if arg != id_col else x.index for arg in args], **kwargs
+            ),
+            meta=meta,
+        )
 
         result = batch.compute()
         return result
 
-    def from_parquet(self, file, id_col=None, time_col=None, flux_col=None,
-                     err_col=None, band_col=None, additional_cols=True,
-                     npartitions=None, partition_size=None):
-        """ Read in parquet file(s) into an ensemble object
+    def from_parquet(
+        self,
+        file,
+        id_col=None,
+        time_col=None,
+        flux_col=None,
+        err_col=None,
+        band_col=None,
+        additional_cols=True,
+        npartitions=None,
+        partition_size=None,
+    ):
+        """Read in parquet file(s) into an ensemble object
 
         Parameters
         ----------
@@ -214,7 +237,9 @@ class ensemble:
             columns = [self._time_col, self._flux_col, self._err_col, self._band_col]
 
         # Read in a parquet file
-        self.data = dd.read_parquet(file, index=self._id_col, columns=columns, split_row_groups=True)
+        self.data = dd.read_parquet(
+            file, index=self._id_col, columns=columns, split_row_groups=True
+        )
 
         if npartitions and npartitions > 1:
             self.data = self.data.repartition(npartitions=npartitions)
@@ -346,8 +371,15 @@ class ensemble:
 
         return result
 
-    def to_timeseries(self, target, id_col=None, time_col=None,
-                      flux_col=None, err_col=None, band_col=None):
+    def to_timeseries(
+        self,
+        target,
+        id_col=None,
+        time_col=None,
+        flux_col=None,
+        err_col=None,
+        band_col=None,
+    ):
         """Construct a timeseries object from one target object_id, assumes
         that the result is a collection of lightcurves (output from query_ids)
 
@@ -390,8 +422,14 @@ class ensemble:
             band_col = self._band_col
 
         df = self.data.loc[target].compute()
-        ts = timeseries()._from_ensemble(data=df, object_id=target, time_label=time_col,
-                                         flux_label=flux_col, err_label=err_col, band_label=band_col)
+        ts = timeseries()._from_ensemble(
+            data=df,
+            object_id=target,
+            time_label=time_col,
+            flux_label=flux_col,
+            err_label=err_col,
+            band_label=band_col,
+        )
         return ts
 
     def flux_to_mag(self, cols):
@@ -418,7 +456,7 @@ class ensemble:
                 cols_mag.append(col)
                 cols_label.append(col)
             else:
-                pre_var, post_var = col[:pos_flux], col[pos_flux + len("Flux"):]
+                pre_var, post_var = col[:pos_flux], col[pos_flux + len("Flux") :]
                 flux_str = pre_var + "Flux"
                 mag_str = pre_var + "AbMag"
                 if col.find("Err") != -1:
@@ -455,8 +493,9 @@ class ensemble:
         index = pd.MultiIndex.from_tuples(tuples, names=["object_id", "band", "index"])
         return index
 
-    def sf2(self, bins=None, band_to_calc=None, combine=False,
-            method="size", sthresh=100):
+    def sf2(
+        self, bins=None, band_to_calc=None, combine=False, method="size", sthresh=100
+    ):
         """Wrapper interface for calling structurefunction2 on the ensemble
 
         Parameters
@@ -491,13 +530,27 @@ class ensemble:
         """
 
         if combine:
-            result = calc_sf2(self.data.index, self.data[self._time_col],
-                              self.data[self._flux_col], self.data[self._err_col],
-                              self.data[self._band_col], bins=bins, band_to_calc=band_to_calc,
-                              combine=combine, method=method, sthresh=sthresh)
+            result = calc_sf2(
+                self.data.index,
+                self.data[self._time_col],
+                self.data[self._flux_col],
+                self.data[self._err_col],
+                self.data[self._band_col],
+                bins=bins,
+                band_to_calc=band_to_calc,
+                combine=combine,
+                method=method,
+                sthresh=sthresh,
+            )
             return result
         else:
-            result = self.batch(calc_sf2, bins=bins, band_to_calc=band_to_calc, combine=False,
-                                method=method, sthresh=sthresh)
+            result = self.batch(
+                calc_sf2,
+                bins=bins,
+                band_to_calc=band_to_calc,
+                combine=False,
+                method=method,
+                sthresh=sthresh,
+            )
 
             return result

--- a/tests/lsstseries_tests/conftest.py
+++ b/tests/lsstseries_tests/conftest.py
@@ -1,0 +1,29 @@
+"""Test fixtures for ensemble manipulations"""
+import pytest
+from dask.distributed import Client
+
+from lsstseries import ensemble
+
+
+@pytest.fixture(scope="package", name="dask_client")
+def dask_client():
+    """Create a single client for use by all unit test cases."""
+    client = Client()
+    yield client
+    client.close()
+
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture
+def parquet_ensemble(dask_client):
+    """Create an ensemble from parquet data."""
+    ens = ensemble(client=dask_client)
+    ens.from_parquet(
+        "tests/lsstseries_tests/data/test_subset.parquet",
+        id_col="ps1_objid",
+        band_col="filterName",
+        flux_col="psFlux",
+        err_col="psFluxErr",
+    )
+
+    return ens

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -5,6 +5,8 @@ import pytest
 
 from lsstseries import analysis, timeseries
 
+# pylint: disable=protected-access
+
 
 def test_stetsonj():
     """
@@ -18,8 +20,8 @@ def test_stetsonj():
         "flux_err": [1] * len(flux_list),
         "band": ["r"] * len(flux_list),
     }
-    ts = timeseries()
-    test_ts = ts.from_dict(data_dict=test_dict)
+    timseries = timeseries()
+    test_ts = timseries.from_dict(data_dict=test_dict)
     print("test StetsonJ value is: " + str(test_ts.stetson_J()["r"]))
     assert test_ts.stetson_J()["r"] == 0.8
 
@@ -40,13 +42,13 @@ def test_sf2_timeseries(lc_id):
         "flux_err": test_yerr,
         "band": ["r"] * len(test_y),
     }
-    ts = timeseries()
-    ts.meta['id'] = lc_id
-    test_ts = ts.from_dict(data_dict=test_dict)
-    res = test_ts.sf2(sthresh=100)
+    timseries = timeseries()
+    timseries.meta["id"] = lc_id
+    test_series = timseries.from_dict(data_dict=test_dict)
+    res = test_series.sf2(sthresh=100)
 
-    assert res['dt'][0] == pytest.approx(3.705, rel=0.001)
-    assert res['sf2'][0] == pytest.approx(0.005365, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
 def test_dt_bins():
@@ -54,7 +56,7 @@ def test_dt_bins():
     Test that the binning routines return the expected properties
     """
     np.random.seed(1)
-    dts = np.random.random_sample(1000)*5 + np.logspace(1, 2, 1000)
+    dts = np.random.random_sample(1000) * 5 + np.logspace(1, 2, 1000)
 
     # test size method
     bins = analysis.structurefunction2._bin_dts(dts, method="size")

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -65,9 +65,9 @@ def test_to_timeseries(parquet_data):
     Test that ensemble.to_timeseries() runs and assigns the correct metadata
     """
     ens = parquet_data
-    ts = ens.to_timeseries('88480000290704349')
+    ts = ens.to_timeseries(88480000290704349)
 
-    assert ts.meta['id'] == '88480000290704349'
+    assert ts.meta['id'] == 88480000290704349
 
 
 def test_build_index():

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -5,7 +5,19 @@ from lsstseries import ensemble
 from lsstseries.analysis.stetsonj import calc_stetson_J
 from lsstseries.analysis.structurefunction2 import calc_sf2
 
+
 # pylint: disable=protected-access
+def test_with():
+    """Test that we open and close a client on enter and exit."""
+    with ensemble() as ens:
+        ens.from_parquet(
+            "tests/lsstseries_tests/data/test_subset.parquet",
+            id_col="ps1_objid",
+            band_col="filterName",
+            flux_col="psFlux",
+            err_col="psFluxErr",
+        )
+        assert ens.data is not None
 
 
 def test_from_parquet(parquet_ensemble):
@@ -14,7 +26,7 @@ def test_from_parquet(parquet_ensemble):
     """
     # Check to make sure the data property was actually set
     assert parquet_ensemble.data is not None
-     
+
     parquet_ensemble.data = parquet_ensemble.data.compute()
     for col in [
         parquet_ensemble._time_col,
@@ -59,9 +71,9 @@ def test_to_timeseries(parquet_ensemble):
     """
     Test that ensemble.to_timeseries() runs and assigns the correct metadata
     """
-    timeseries = parquet_ensemble.to_timeseries(88480000290704349)
+    ts = parquet_ensemble.to_timeseries(88480000290704349)
 
-    assert timeseries.meta["id"] == 88480000290704349
+    assert ts.meta["id"] == 88480000290704349
 
 
 def test_build_index(dask_client):

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -5,72 +5,66 @@ from lsstseries import ensemble
 from lsstseries.analysis.stetsonj import calc_stetson_J
 from lsstseries.analysis.structurefunction2 import calc_sf2
 
-
-@pytest.fixture
-def parquet_data():
-    ens = ensemble()
-    ens.from_parquet("tests/lsstseries_tests/data/test_subset.parquet", id_col='ps1_objid', band_col='filterName',
-                     flux_col='psFlux', err_col='psFluxErr')
-
-    yield ens
-    ens.client.close()
+# pylint: disable=protected-access
 
 
-def test_from_parquet(parquet_data):
+def test_from_parquet(parquet_ensemble):
     """
     Test that ensemble.from_parquet() successfully loads a parquet file
     """
-    ens = parquet_data
+    # Check to make sure the data property was actually set
+    assert parquet_ensemble.data is not None
+     
+    parquet_ensemble.data = parquet_ensemble.data.compute()
+    for col in [
+        parquet_ensemble._time_col,
+        parquet_ensemble._flux_col,
+        parquet_ensemble._err_col,
+        parquet_ensemble._band_col,
+    ]:
+        # Check to make sure the critical quantity labels are bound to real columns
+        assert parquet_ensemble.data[col] is not None
 
-    assert ens.data is not None  # Check to make sure the data property was actually set
-    ens.data = ens.data.compute()
-    for col in [ens._time_col, ens._flux_col, ens._err_col, ens._band_col]:
-        ens.data[col]  # Check to make sure the critical quantity labels are bound to real columns
 
-
-def test_counts(parquet_data):
+def test_counts(parquet_ensemble):
     """
     Test that ensemble.count() runs and returns the first five values correctly
     """
-    ens = parquet_data
-
-    count = ens.count()
+    count = parquet_ensemble.count()
     assert list(count.values[0:5]) == [499, 343, 337, 195, 188]
 
 
-def test_prune(parquet_data):
+def test_prune(parquet_ensemble):
     """
     Test that ensemble.prune() appropriately filters the dataframe
     """
-    ens = parquet_data
-
     threshold = 10
-    ens.prune(threshold)
-    assert ens.count(ascending=False).values[0] >= threshold
+    parquet_ensemble.prune(threshold)
+    assert parquet_ensemble.count(ascending=False).values[0] >= threshold
 
 
-def test_batch(parquet_data):
+def test_batch(parquet_ensemble):
     """
     Test that ensemble.batch() returns the correct values of the first result
     """
-    ens = parquet_data
-    result = ens.prune(10).dropna(1).batch(calc_stetson_J, band_to_calc=None)
+    result = (
+        parquet_ensemble.prune(10).dropna(1).batch(calc_stetson_J, band_to_calc=None)
+    )
 
-    assert pytest.approx(result.values[0]['g'], 0.001) == -0.04174282
-    assert pytest.approx(result.values[0]['r'], 0.001) == 0.6075282
+    assert pytest.approx(result.values[0]["g"], 0.001) == -0.04174282
+    assert pytest.approx(result.values[0]["r"], 0.001) == 0.6075282
 
 
-def test_to_timeseries(parquet_data):
+def test_to_timeseries(parquet_ensemble):
     """
     Test that ensemble.to_timeseries() runs and assigns the correct metadata
     """
-    ens = parquet_data
-    ts = ens.to_timeseries(88480000290704349)
+    timeseries = parquet_ensemble.to_timeseries(88480000290704349)
 
-    assert ts.meta['id'] == 88480000290704349
+    assert timeseries.meta["id"] == 88480000290704349
 
 
-def test_build_index():
+def test_build_index(dask_client):
     """
     Test that ensemble indexing returns expected behavior
     """
@@ -78,25 +72,24 @@ def test_build_index():
     obj_ids = [1, 1, 1, 2, 1, 2, 2]
     bands = ["u", "u", "u", "g", "g", "u", "u"]
 
-    ens = ensemble()
+    ens = ensemble(client=dask_client)
     result = list(ens._build_index(obj_ids, bands).get_level_values(2))
     target = [0, 1, 2, 0, 0, 0, 1]
     assert result == target
-    ens.client.close()
 
 
 @pytest.mark.parametrize("method", ["size", "length", "loglength"])
 @pytest.mark.parametrize("combine", [True, False])
 @pytest.mark.parametrize("sthresh", [50, 100])
-def test_sf2(parquet_data, method, combine, sthresh):
+def test_sf2(parquet_ensemble, method, combine, sthresh):
     """
     Test calling sf2 from the ensemble
     """
 
-    ens = parquet_data
-
-    res_sf2 = ens.sf2(combine=combine, method=method, sthresh=sthresh)
-    res_batch = ens.batch(calc_sf2, combine=combine, method=method, sthresh=sthresh)
+    res_sf2 = parquet_ensemble.sf2(combine=combine, method=method, sthresh=sthresh)
+    res_batch = parquet_ensemble.batch(
+        calc_sf2, combine=combine, method=method, sthresh=sthresh
+    )
 
     if combine:
         assert not res_sf2.equals(res_batch)  # output should be different


### PR DESCRIPTION
- Allows for a single dask client to be created for all unit tests. This speeds up execution and reduces warnings.
- Locally, unit test execution goes from 35-45 seconds to 8-9 seconds
- In github CI, execution goes from 67-77 seconds to 16-19 seconds
- Addresses nearby black formatting and pylint warnings