### PR TITLE
Map partitions

### DIFF
--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -208,11 +208,11 @@ class Ensemble:
 
         if use_map:  # use map_partitions
             id_col = self._id_col  # need to grab this before mapping
-            batch = self._data.map_partitions(lambda x: x.groupby(id_col).apply(
+            batch = self._data.map_partitions(lambda x: x.groupby(id_col, group_keys=False).apply(
                 lambda y: func(*[y[arg] if arg != id_col else y.index for arg in args],
                                **kwargs)), meta=meta)
         else:  # use groupby
-            batch = self._data.groupby(self._id_col).apply(
+            batch = self._data.groupby(self._id_col, group_keys=False).apply(
                 lambda x: func(
                     *[x[arg] if arg != id_col else x.index for arg in args], **kwargs
                 ),

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -146,7 +146,7 @@ class Ensemble:
         self._data = self._data[self._data[col_name] >= threshold]
         return self
 
-    def batch(self, func, meta=None, *args, **kwargs):
+    def batch(self, func, meta=None, use_map=True, *args, **kwargs):
         """Run a function from lsstseries.TimeSeries on the available ids
 
         Parameters
@@ -158,6 +158,11 @@ class Ensemble:
             the results. Overridden by lsstseries for lsstseries
             functions. If none, attempts to coerce the result to a
             pandas.series.
+        use_map : `boolean`
+            Determines whether `dask.dataframe.DataFrame.map_partitions` is
+            used (True). Using map_partitions is generally more efficient, but
+            requires the data from each lightcurve is housed in a single
+            partition. If False, a groupby will be performed instead.
         *args:
             Denotes the ensemble columns to use as inputs for a function,
             order must be correct for function. If passing a lsstseries
@@ -201,12 +206,18 @@ class Ensemble:
 
         id_col = self._id_col  # pre-compute needed for dask in lambda function
 
-        batch = self._data.groupby(self._id_col).apply(
-            lambda x: func(
-                *[x[arg] if arg != id_col else x.index for arg in args], **kwargs
-            ),
-            meta=meta,
-        )
+        if use_map:  # use map_partitions
+            id_col = self._id_col  # need to grab this before mapping
+            batch = self._data.map_partitions(lambda x: x.groupby(id_col).apply(
+                lambda y: func(*[y[arg] if arg != id_col else y.index for arg in args],
+                               **kwargs)), meta=meta)
+        else:  # use groupby
+            batch = self._data.groupby(self._id_col).apply(
+                lambda x: func(
+                    *[x[arg] if arg != id_col else x.index for arg in args], **kwargs
+                ),
+                meta=meta,
+            )
 
         result = batch.compute()
         return result
@@ -532,7 +543,13 @@ class Ensemble:
         return index
 
     def sf2(
-        self, bins=None, band_to_calc=None, combine=False, method="size", sthresh=100
+        self,
+        bins=None,
+        band_to_calc=None,
+        combine=False,
+        method="size",
+        sthresh=100,
+        use_map=True
     ):
         """Wrapper interface for calling structurefunction2 on the ensemble
 
@@ -555,6 +572,11 @@ class Ensemble:
             bins of equal length in log time.
         sthresh : 'int'
             Target number of samples per bin.
+        use_map : `boolean`
+            Determines whether `dask.dataframe.DataFrame.map_partitions` is
+            used (True). Using map_partitions is generally more efficient, but
+            requires the data from each lightcurve is housed in a single
+            partition. If False, a groupby will be performed instead.
 
         Returns
         ----------
@@ -589,6 +611,7 @@ class Ensemble:
                 combine=False,
                 method=method,
                 sthresh=sthresh,
+                use_map=use_map
             )
 
             return result

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -68,12 +68,13 @@ def test_prune(parquet_ensemble):
     assert parquet_ensemble.count(ascending=False).values[0] >= threshold
 
 
-def test_batch(parquet_ensemble):
+@pytest.mark.parametrize("use_map", [True, False])
+def test_batch(parquet_ensemble, use_map):
     """
     Test that ensemble.batch() returns the correct values of the first result
     """
     result = (
-        parquet_ensemble.prune(10).dropna(1).batch(calc_stetson_J, band_to_calc=None)
+        parquet_ensemble.prune(10).dropna(1).batch(calc_stetson_J, use_map=use_map, band_to_calc=None)
     )
 
     assert pytest.approx(result.values[0]["g"], 0.001) == -0.04174282
@@ -106,14 +107,14 @@ def test_build_index(dask_client):
 @pytest.mark.parametrize("method", ["size", "length", "loglength"])
 @pytest.mark.parametrize("combine", [True, False])
 @pytest.mark.parametrize("sthresh", [50, 100])
-def test_sf2(parquet_ensemble, method, combine, sthresh):
+def test_sf2(parquet_ensemble, method, combine, sthresh, use_map=False):
     """
     Test calling sf2 from the ensemble
     """
 
-    res_sf2 = parquet_ensemble.sf2(combine=combine, method=method, sthresh=sthresh)
+    res_sf2 = parquet_ensemble.sf2(combine=combine, method=method, sthresh=sthresh, use_map=use_map)
     res_batch = parquet_ensemble.batch(
-        calc_sf2, combine=combine, method=method, sthresh=sthresh
+        calc_sf2, use_map=False, combine=combine, method=method, sthresh=sthresh
     )
 
     if combine:

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -114,7 +114,7 @@ def test_sf2(parquet_ensemble, method, combine, sthresh, use_map=False):
 
     res_sf2 = parquet_ensemble.sf2(combine=combine, method=method, sthresh=sthresh, use_map=use_map)
     res_batch = parquet_ensemble.batch(
-        calc_sf2, use_map=False, combine=combine, method=method, sthresh=sthresh
+        calc_sf2, use_map=use_map, combine=combine, method=method, sthresh=sthresh
     )
 
     if combine:


### PR DESCRIPTION
By default, use map_partitions instead of an ensemble-wide groupby. Though the ensemble-wide groupby is still available to use if use_map is set to false. Map partitions creates more efficient task graphs and avoids data shuffling costs, but has the added requirement that each light curve is confined to a single partition.

Closes #19 