### PR TITLE
convert series to numpy arrays in batch function

### DIFF
--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -209,12 +209,12 @@ class Ensemble:
         if use_map:  # use map_partitions
             id_col = self._id_col  # need to grab this before mapping
             batch = self._data.map_partitions(lambda x: x.groupby(id_col, group_keys=False).apply(
-                lambda y: func(*[y[arg] if arg != id_col else y.index for arg in args],
+                lambda y: func(*[y[arg].to_numpy() if arg != id_col else y.index.to_numpy() for arg in args],
                                **kwargs)), meta=meta)
         else:  # use groupby
             batch = self._data.groupby(self._id_col, group_keys=False).apply(
                 lambda x: func(
-                    *[x[arg] if arg != id_col else x.index for arg in args], **kwargs
+                    *[x[arg].to_numpy() if arg != id_col else x.index.to_numpy() for arg in args], **kwargs
                 ),
                 meta=meta,
             )


### PR DESCRIPTION
Ensemble.batch passes the data columns along to analysis functions as pandas.series objects, as our analysis functions are designed to consider 1d array-like inputs, this can introduce a sizeable slowdown. By casting these series objects to numpy arrays, we see speedups of ~10x when testing on calc_stetson_J. Calc_sf2 does not benefit from the change, but that's potentially because of #46