### PR TITLE
Replace the Pandas cut and qcut with numpy functions

### DIFF
--- a/src/lsstseries/analysis/structurefunction2.py
+++ b/src/lsstseries/analysis/structurefunction2.py
@@ -241,26 +241,26 @@ def _bin_dts(dts, method="size", sthresh=100):
     """
 
     num_bins = int(np.ceil(len(dts) / sthresh))
+    dts_unique = np.unique(dts)
     if method == "size":
         quantiles = np.linspace(0.0, 1.0, num_bins + 1)
-        bins = np.quantile(dts, quantiles)
+        bins = np.quantile(dts_unique, quantiles)
         return bins
 
     elif method == "length":
         # Compute num_bins equally spaced bins.
-        min_val = dts.min()
-        max_val = dts.max()
+        min_val = dts_unique.min()
+        max_val = dts_unique.max()
         bins = np.linspace(min_val, max_val, num_bins + 1)
 
         # Extend the start of the first bin by 0.1% of the range to
         # include the first element. Note this is also done to match
         # Panda's cut function.
         bins[0] -= 0.001 * (max_val - min_val)
-
         return bins
 
     elif method == "loglength":
-        log_vals = np.log(dts)
+        log_vals = np.log(dts_unique)
 
         # Compute num_bins equally spaced bins in log space.
         min_val = log_vals.min()

--- a/src/lsstseries/analysis/structurefunction2.py
+++ b/src/lsstseries/analysis/structurefunction2.py
@@ -240,19 +240,38 @@ def _bin_dts(dts, method="size", sthresh=100):
         The returned bins array.
     """
 
+    num_bins = int(np.ceil(len(dts) / sthresh))
     if method == "size":
-        quantiles = int(np.ceil(len(dts) / sthresh))
-        _, bins = pd.qcut(dts, q=quantiles, retbins=True, duplicates="drop")
+        quantiles = np.linspace(0.0, 1.0, num_bins + 1)
+        bins = np.quantile(dts, quantiles)
         return bins
 
     elif method == "length":
-        nbins = int(np.ceil(len(dts) / sthresh))
-        _, bins = pd.cut(dts, bins=nbins, retbins=True, duplicates="drop")
+        # Compute num_bins equally spaced bins.
+        min_val = dts.min()
+        max_val = dts.max()
+        bins = np.linspace(min_val, max_val, num_bins + 1)
+
+        # Extend the start of the first bin by 0.1% of the range to
+        # include the first element. Note this is also done to match
+        # Panda's cut function.
+        bins[0] -= 0.001 * (max_val - min_val)
+
         return bins
 
     elif method == "loglength":
-        nbins = int(np.ceil(len(dts) / sthresh))
-        _, bins = pd.cut(np.log(dts), bins=nbins, retbins=True, duplicates="drop")
+        log_vals = np.log(dts)
+
+        # Compute num_bins equally spaced bins in log space.
+        min_val = log_vals.min()
+        max_val = log_vals.max()
+        bins = np.linspace(min_val, max_val, num_bins + 1)
+
+        # Extend the start of the first bin by 0.1% of the range to
+        # include the first element. Note this is also done to match
+        # Panda's cut function.
+        bins[0] -= 0.001 * (max_val - min_val)
+
         return np.exp(bins)
 
     else:

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -55,6 +55,19 @@ def test_dt_bins():
     """
     Test that the binning routines return the expected properties
     """
+    # Test on some known data.
+    dts = np.array([(201.0 - i) for i in range(200)])
+
+    bins = analysis.structurefunction2._bin_dts(dts, method="size")
+    np.testing.assert_allclose(bins, [2.0, 101.5, 201.0])
+
+    bins = analysis.structurefunction2._bin_dts(dts, method="length")
+    np.testing.assert_allclose(bins, [1.801, 101.5, 201.0])
+
+    bins = analysis.structurefunction2._bin_dts(dts, method="loglength")
+    np.testing.assert_allclose(bins, [1.99080091, 20.04993766, 201.0], rtol=1e-5)
+
+    # Test on large randomized data (with a constant seed).
     np.random.seed(1)
     dts = np.random.random_sample(1000) * 5 + np.logspace(1, 2, 1000)
 


### PR DESCRIPTION
Replacing `qcut` with numpy `quantile` leads to a >8x speedup. Since we are only using the bins from the `cut` function, we can replace those with a `linspace`.

There is some extra logic to ensure this is a complete no-op (pandas extends the lower bound of the fit bin in the cut function by 0.1% of the range). I'm not sure if we need to keep that or not. But including it right now for consistency.