### PR TITLE
Object Source Refactor

### DIFF
--- a/docs/notebooks/scaling_to_large_data.ipynb
+++ b/docs/notebooks/scaling_to_large_data.ipynb
@@ -172,7 +172,7 @@
     "                band_col='filterName',\n",
     "                partition_size='5KB')\n",
     "\n",
-    "ens._data"
+    "ens.info()"
    ]
   },
   {

--- a/docs/notebooks/working_with_the_ensemble.ipynb
+++ b/docs/notebooks/working_with_the_ensemble.ipynb
@@ -49,6 +49,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## The Object and Source Frames\n",
+    "The `Ensemble` maintains two dataframes under the hood, the \"object dataframe\" and the \"source dataframe\". This borrows from the Rubin Observatories object-source convention, where object denotes a given astronomical object and source is the collection of measurements of that object. Essentially, the Object frame stores one-off information about objects, and the source frame stores the available time-domain data. As a result, Ensemble functions that operate on the underlying dataframes need to be pointed at either object or source. In most cases, the default is the object table as it's a more helpful interface for understanding the contents of the ensemble, especially when dealing with large volumes of data."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Dask and \"Lazy Evaluation\"\n",
     "\n",
     "Before going any further, the `Ensemble` is built on top of `Dask`, which brings with it a powerful framework for parallelization and scalability. However, there are some differences in how `Dask` code works that, if you're unfamiliar with it, is worth establishing right here at the get-go. The first is that `Dask` evaluates code \"lazily\". Meaning that many operations are not executed when the line of code is run, but instead are added to a scheduler to be executed when the result is actually needed. See below for an example:"
@@ -60,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens._data  # We have not actually loaded any data into memory"
+    "ens._source  # We have not actually loaded any data into memory"
    ]
   },
   {
@@ -77,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.compute() # Compute lets dask know we're ready to bring the data into memory"
+    "ens.compute(\"source\") # Compute lets dask know we're ready to bring the data into memory"
    ]
   },
   {
@@ -116,7 +125,7 @@
    "source": [
     "# Inspection\n",
     "\n",
-    "ens.info(verbose=True, memory_usage=True) # Grabs high level information about the dataframe\n"
+    "ens.info(verbose=True, memory_usage=True) # Grabs high level information about the dataframes\n"
    ]
   },
   {
@@ -133,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.head(5) # Grabs the first 5 rows"
+    "ens.head(\"object\", 5) # Grabs the first 5 rows of the object table"
    ]
   },
   {
@@ -143,7 +152,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "ens.tail(5) # Grabs the last 5 rows"
+    "ens.tail(\"source\", 5) # Grabs the last 5 rows of the source table"
    ]
   },
   {
@@ -160,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.compute()"
+    "ens.compute(\"source\")"
    ]
   },
   {

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -19,7 +19,8 @@ class Ensemble:
         self._source = None  # Source Table
         self._object = None  # Object Table
 
-        self.dirty = False  # Dirty Flag
+        self._sor_dirty = False  # Source Dirty Flag
+        self._obj_dirty = False  # Object Dirty Flag
 
         # Assign Default Values for critical column quantities
         # Source
@@ -84,31 +85,42 @@ class Ensemble:
         counts: `pandas.series`
             A series of counts by object
         """
+        # Sync tables if user wants to retrieve their information
+        if self._sor_dirty or self._obj_dirty:
+            self = self._sync_tables
+
         print("Object Table")
         self._object.info(verbose=verbose, memory_usage=memory_usage, **kwargs)
         print("Source Table")
         self._source.info(verbose=verbose, memory_usage=memory_usage, **kwargs)
-        print(f"Tables in-sync: {not self.dirty}")
 
     def compute(self, table=None, **kwargs):
         """Wrapper for dask.dataframe.DataFrame.compute()"""
 
-        if self.dirty:
-            self = self._sync_tables()
-
         if table:
             if table == "object":
+                if self._sor_dirty:  # object table should be updated
+                    self = self._sync_tables()
                 return self._object.compute(**kwargs)
             elif table == "source":
+                if self._obj_dirty:  # source table should be updated
+                    self = self._sync_tables()
                 return self._source.compute(**kwargs)
         else:
+            if self._sor_dirty or self._obj_dirty:
+                self = self._sync_tables()
+
             return (self._object.compute(**kwargs), self._source.compute(**kwargs))
 
     def columns(self, table="object"):
         """Retrieve columns from dask dataframe"""
         if table == "object":
+            if self._sor_dirty:  # object table should be updated
+                self = self._sync_tables()
             return self._object.columns
         elif table == "source":
+            if self._obj_dirty:  # source table should be updated
+                self = self._sync_tables()
             return self._source.columns
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
@@ -117,8 +129,12 @@ class Ensemble:
         """Wrapper for dask.dataframe.DataFrame.head()"""
 
         if table == "object":
+            if self._sor_dirty:  # object table should be updated
+                self = self._sync_tables()
             return self._object.head(n=n, **kwargs)
         elif table == "source":
+            if self._obj_dirty:  # source table should be updated
+                self = self._sync_tables()
             return self._source.head(n=n, **kwargs)
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
@@ -127,8 +143,12 @@ class Ensemble:
         """Wrapper for dask.dataframe.DataFrame.tail()"""
 
         if table == "object":
+            if self._sor_dirty:  # object table should be updated
+                self = self._sync_tables()
             return self._object.tail(n=n, **kwargs)
         elif table == "source":
+            if self._obj_dirty:  # source table should be updated
+                self = self._sync_tables()
             return self._source.tail(n=n, **kwargs)
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")
@@ -149,7 +169,7 @@ class Ensemble:
             scheme
         """
         self._source = self._source[self._source.isnull().sum(axis=1) < threshold]
-        self.dirty = True  # This operation modifies the source table
+        self._sor_dirty = True  # This operation modifies the source table
         return self
 
     def filter(self, on, criteria, table="object"):
@@ -183,8 +203,8 @@ class Ensemble:
         if not col_name:
             col_name = self._nobs_col
 
-        # Sync Required
-        if self.dirty:
+        # Sync Required if source is dirty
+        if self._sor_dirty:
             self = self._sync_tables
 
         # Mask on object table
@@ -196,7 +216,7 @@ class Ensemble:
         #                                 how='right', lsuffix="obj", rsuffix="sor")
         #  self._source = self._source.drop(list(self._object.columns), axis=1)
 
-        self.dirty = True  # Source Table is now out of sync
+        self._obj_dirty = True  # Object Table is now dirty
 
         return self
 
@@ -239,6 +259,11 @@ class Ensemble:
         ensemble.batch(calc_stetson_J, band_to_calc='i')
         `
         """
+
+        # Needs tables to be in sync
+        if self._sor_dirty or self._obj_dirty:
+            self = self._sync_tables()
+
         known_cols = {
             "calc_stetson_J": [self._flux_col, self._err_col, self._band_col],
             "calc_sf2": [
@@ -387,21 +412,25 @@ class Ensemble:
     def _sync_tables(self):
         """Sync operation to align both tables"""
 
-        # Sync Object to Source; remove any missing objects from source
-        self._source = self._source.join(self._object, on=self._id_col,
-                                         how='right', lsuffix="obj", rsuffix="sor")
-        self._source = self._source.drop(list(self._object.columns), axis=1)
+        if self._obj_dirty:
+            # Sync Object to Source; remove any missing objects from source
+            self._source = self._source.join(self._object, on=self._id_col,
+                                             how='right', lsuffix="obj", rsuffix="sor")
+            self._source = self._source.drop(list(self._object.columns), axis=1)
 
-        # Generate a new object table; updates n_obs, removes missing ids
-        new_obj = self._generate_object_table()
+        if self._sor_dirty:  # not elif
+            # Generate a new object table; updates n_obs, removes missing ids
+            new_obj = self._generate_object_table()
 
-        # Join old obj to new obj; pulls in other existing obj columns
-        self._object = new_obj.join(self._object, on=self._id_col,
-                                    how="left", lsuffix="", rsuffix="_old")
-        old_cols = [col for col in list(self._object.columns) if "_old" in col]
-        self._object = self._object.drop(old_cols, axis=1)
+            # Join old obj to new obj; pulls in other existing obj columns
+            self._object = new_obj.join(self._object, on=self._id_col,
+                                        how="left", lsuffix="", rsuffix="_old")
+            old_cols = [col for col in list(self._object.columns) if "_old" in col]
+            self._object = self._object.drop(old_cols, axis=1)
 
-        self.dirty = False  # Now synced and clean
+        # Now synced and clean
+        self._sor_dirty = False
+        self._obj_dirty = False
         return self
 
     def tap_token(self, token):

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -422,10 +422,7 @@ class Ensemble:
         if self._obj_dirty:
             # Sync Object to Source; remove any missing objects from source
 
-            # Try a merge instead?
             self._source = self._source.merge(self._object, how="right", on=[self._id_col])
-            #self._source = self._source.join(self._object, on=self._id_col,
-            #                                 how='right', lsuffix="obj", rsuffix="sor")
             self._source = self._source.drop(list(self._object.columns), axis=1)
 
         if self._sor_dirty:  # not elif
@@ -612,7 +609,7 @@ class Ensemble:
         if band_col is None:
             band_col = self._band_col
 
-        df = self._data.loc[target].compute()
+        df = self._source.loc[target].compute()
         ts = TimeSeries()._from_ensemble(
             data=df,
             object_id=target,
@@ -735,11 +732,11 @@ class Ensemble:
 
         if combine:
             result = calc_sf2(
-                self._data.index,
-                self._data[self._time_col],
-                self._data[self._flux_col],
-                self._data[self._err_col],
-                self._data[self._band_col],
+                self._source.index,
+                self._source[self._time_col],
+                self._source[self._flux_col],
+                self._source[self._err_col],
+                self._source[self._band_col],
                 bins=bins,
                 band_to_calc=band_to_calc,
                 combine=combine,

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -421,8 +421,11 @@ class Ensemble:
 
         if self._obj_dirty:
             # Sync Object to Source; remove any missing objects from source
-            self._source = self._source.join(self._object, on=self._id_col,
-                                             how='right', lsuffix="obj", rsuffix="sor")
+
+            # Try a merge instead?
+            self._source = self._source.merge(self._object, how="right", on=[self._id_col])
+            #self._source = self._source.join(self._object, on=self._id_col,
+            #                                 how='right', lsuffix="obj", rsuffix="sor")
             self._source = self._source.drop(list(self._object.columns), axis=1)
 
         if self._sor_dirty:  # not elif

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -115,12 +115,8 @@ class Ensemble:
     def columns(self, table="object"):
         """Retrieve columns from dask dataframe"""
         if table == "object":
-            if self._source_dirty:  # object table should be updated
-                self = self._sync_tables()
             return self._object.columns
         elif table == "source":
-            if self._object_dirty:  # source table should be updated
-                self = self._sync_tables()
             return self._source.columns
         else:
             raise ValueError(f"{table} is not one of 'object' or 'source'")

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -87,7 +87,7 @@ class Ensemble:
         """
         # Sync tables if user wants to retrieve their information
         if self._sor_dirty or self._obj_dirty:
-            self = self._sync_tables
+            self = self._sync_tables()
 
         print("Object Table")
         self._object.info(verbose=verbose, memory_usage=memory_usage, **kwargs)
@@ -205,7 +205,7 @@ class Ensemble:
 
         # Sync Required if source is dirty
         if self._sor_dirty:
-            self = self._sync_tables
+            self = self._sync_tables()
 
         # Mask on object table
         mask = self._object[col_name] >= threshold

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -430,8 +430,7 @@ class Ensemble:
             new_obj = self._generate_object_table()
 
             # Join old obj to new obj; pulls in other existing obj columns
-            self._object = new_obj.join(self._object, on=self._id_col,
-                                        how="left", lsuffix="", rsuffix="_old")
+            self._object = new_obj.join(self._object, on=self._id_col, how="left", lsuffix="", rsuffix="_old")
             old_cols = [col for col in list(self._object.columns) if "_old" in col]
             self._object = self._object.drop(old_cols, axis=1)
 

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -104,7 +104,7 @@ class Ensemble:
                 return self._object.compute(**kwargs)
             elif table == "source":
                 if self._obj_dirty:  # source table should be updated
-                    self = self._sync_tables()
+                    self._sync_tables()
                 return self._source.compute(**kwargs)
         else:
             if self._sor_dirty or self._obj_dirty:

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -191,15 +191,6 @@ class Ensemble:
         ensemble: `lsstseries.ensemble.Ensemble`
             The ensemble object with pruned rows removed
         """
-        """
-        if col_name not in self._data.columns:
-            counts = self._data.groupby(self._id_col).count()
-            counts = counts.rename(columns={self._time_col: col_name})[[col_name]]
-            self._data = self._data.join(counts, how="left")
-
-        self._data = self._data[self._data[col_name] >= threshold]
-        return self
-        """
         if not col_name:
             col_name = self._nobs_col
 
@@ -210,11 +201,6 @@ class Ensemble:
         # Mask on object table
         mask = self._object[col_name] >= threshold
         self._object = self._object[mask]
-
-        #  Join object to source; joins may not be ideal here, have to drop cols
-        #  self._source = self._source.join(self._object, on=self._id_col,
-        #                                 how='right', lsuffix="obj", rsuffix="sor")
-        #  self._source = self._source.drop(list(self._object.columns), axis=1)
 
         self._obj_dirty = True  # Object Table is now dirty
 

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -57,11 +57,14 @@ def test_sync_tables(parquet_ensemble):
     Test that _table_sync works as expected
     """
 
+    assert len(parquet_ensemble.compute("object")) == 15
+    assert len(parquet_ensemble.compute("source")) == 2000
+
     parquet_ensemble.prune(50, col_name='nobs_r').prune(50, col_name='nobs_g')
-    assert parquet_ensemble._obj_dirty  # Prune should set the object dirty flag
+    assert parquet_ensemble._object_dirty  # Prune should set the object dirty flag
 
     parquet_ensemble.dropna(1)
-    assert parquet_ensemble._sor_dirty  # Dropna should set the source dirty flag
+    assert parquet_ensemble._source_dirty  # Dropna should set the source dirty flag
 
     parquet_ensemble._sync_tables()
 
@@ -70,8 +73,8 @@ def test_sync_tables(parquet_ensemble):
     assert len(parquet_ensemble.compute("source")) == 1562
 
     # dirty flags should be unset after sync
-    assert not parquet_ensemble._obj_dirty
-    assert not parquet_ensemble._sor_dirty
+    assert not parquet_ensemble._object_dirty
+    assert not parquet_ensemble._source_dirty
 
 
 def test_prune(parquet_ensemble):

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -1,6 +1,6 @@
 """Test ensemble manipulations"""
-import pytest
 import numpy as np
+import pytest
 
 from lsstseries import Ensemble
 from lsstseries.analysis.stetsonj import calc_stetson_J
@@ -59,7 +59,7 @@ def test_prune(parquet_ensemble):
     threshold = 10
     parquet_ensemble.prune(threshold)
 
-    assert not np.any(parquet_ensemble._object['nobs_total'].values < threshold)
+    assert not np.any(parquet_ensemble._object["nobs_total"].values < threshold)
 
 
 @pytest.mark.parametrize("use_map", [True, False])


### PR DESCRIPTION
This PR implements the Object Source Refactor, where the _data dataframe has been split into the _object and _source dataframes.

Main Highlights:
* _object and _source under the hood, many dataframe utility functions now include the `table` arg for picking which table to operate on, e.g. `ensemble.head(table="object", 5)`
* Both the _source and _object tables have a dedicated dirty flag, which indicates when they've been modified. Operations that access data from either of the tables will first check the dirty flags to see if a sync operation should be done. Syncs don't need to be done when pulling from a dirty table, only when you need to pull from the other table. For example, if I trim NaNs from source, source is now dirty, if I then want to load the object table then I will need to sync as it hasn't been synced with the modified source table.
* The object table is created from the source table if not provided, there is some basic support for providing an existing object table but it's likely something we'll want to work on further. I was initially using the hipscatted ztf to test this, and it worked but I think more work will need to be done to properly support the hipscat format.
* I didn't see much if any performance hit, the inclusion of n_obs columns makes filtering operations like prune much quicker, seems to counterbalance the extra computations that are done to keep the tables in-sync
* Updated the docs and tests