### PR TITLE
Give _sync_tables the ability to persist objects that have no sources 

### DIFF
--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -483,10 +483,10 @@ class Ensemble:
         # objects, then copy them into the res table with counts of zero.
         if self.keep_empty_objects and self._object is not None:
             # Check that there are existing object ids.
-            object_inds = self._object.index.values.compute()
+            object_inds = self._object.index.unique().values.compute()
             if len(object_inds) > 0:
                 # Determine which object IDs are missing from the source table.
-                source_inds = self._source.index.values.compute()
+                source_inds = self._source.index.unique().values.compute()
                 missing_inds = np.setdiff1d(object_inds, source_inds).tolist()
 
                 # Create a dataframe of the missing IDs with zeros for all bands and counts.

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -482,6 +482,8 @@ class Ensemble:
         # If the ensemble's keep_empty_objects attribute is True and there are previous
         # objects, then copy them into the res table with counts of zero.
         if self.keep_empty_objects and self._object is not None:
+            prev_partitions = self._object.npartitions
+
             # Check that there are existing object ids.
             object_inds = self._object.index.unique().values.compute()
             if len(object_inds) > 0:
@@ -499,6 +501,7 @@ class Ensemble:
 
                 # Concatonate the zero dataframe onto the results.
                 res = dd.concat([res, zero_ddf], interleave_partitions=True).astype(int)
+                res = res.repartition(npartitions=prev_partitions)
 
         # Rename bands to nobs_[band]
         band_cols = {col: f"nobs_{col}" for col in list(res.columns)}

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -250,6 +250,7 @@ def test_keep_zeros(parquet_ensemble):
     """Test that we can sync the tables and keep objects with zero sources."""
     parquet_ensemble.keep_empty_objects = True
 
+    prev_npartitions = parquet_ensemble._object.npartitions
     old_objects_pdf = parquet_ensemble._object.compute()
     pdf = parquet_ensemble._source.compute()
 
@@ -266,6 +267,7 @@ def test_keep_zeros(parquet_ensemble):
 
     new_objects_pdf = parquet_ensemble._object.compute()
     assert len(new_objects_pdf.index) == len(old_objects_pdf.index)
+    assert parquet_ensemble._object.npartitions == prev_npartitions
 
     # Check that all counts have stayed the same except the filtered index,
     # which should now be all zeros.

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -232,7 +232,7 @@ def test_dropna(parquet_ensemble):
     assert len(parquet_ensemble._source.compute().index) == parquet_length - occurrences
 
     # Sync the table and check that the number of objects decreased.
-    parquet_ensemble._sync_tables(keep_zero_entries=False)
+    parquet_ensemble._sync_tables()
 
     new_objects_pdf = parquet_ensemble._object.compute()
     assert len(new_objects_pdf.index) == len(old_objects_pdf.index) - 1
@@ -248,6 +248,8 @@ def test_dropna(parquet_ensemble):
 
 def test_keep_zeros(parquet_ensemble):
     """Test that we can sync the tables and keep objects with zero sources."""
+    parquet_ensemble.keep_empty_objects = True
+
     old_objects_pdf = parquet_ensemble._object.compute()
     pdf = parquet_ensemble._source.compute()
 
@@ -260,7 +262,7 @@ def test_keep_zeros(parquet_ensemble):
 
     # Sync the table and check that the number of objects decreased.
     parquet_ensemble.dropna(1)
-    parquet_ensemble._sync_tables(keep_zero_entries=True)
+    parquet_ensemble._sync_tables()
 
     new_objects_pdf = parquet_ensemble._object.compute()
     assert len(new_objects_pdf.index) == len(old_objects_pdf.index)

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -209,6 +209,7 @@ def test_sync_tables(parquet_ensemble):
 
 
 def test_dropna(parquet_ensemble):
+    old_objects_pdf = parquet_ensemble._object.compute()
     pdf = parquet_ensemble._source.compute()
     parquet_length = len(pdf.index)
 
@@ -229,6 +230,49 @@ def test_dropna(parquet_ensemble):
     # Try dropping NaNs and confirm that we did.
     parquet_ensemble.dropna(1)
     assert len(parquet_ensemble._source.compute().index) == parquet_length - occurrences
+
+    # Sync the table and check that the number of objects decreased.
+    parquet_ensemble._sync_tables(keep_zero_entries=False)
+
+    new_objects_pdf = parquet_ensemble._object.compute()
+    assert len(new_objects_pdf.index) == len(old_objects_pdf.index) - 1
+
+    # Assert the filtered ID is no longer in the objects.
+    assert not valid_id in new_objects_pdf.index.values
+
+    # Check that none of the other counts have changed.
+    for i in new_objects_pdf.index.values:
+        for c in new_objects_pdf.columns.values:
+            assert new_objects_pdf.loc[i, c] == old_objects_pdf.loc[i, c]
+
+
+def test_keep_zeros(parquet_ensemble):
+    """Test that we can sync the tables and keep objects with zero sources."""
+    old_objects_pdf = parquet_ensemble._object.compute()
+    pdf = parquet_ensemble._source.compute()
+
+    # Set the psFlux values for one object to NaN so we can drop it.
+    # We do this on the instantiated object (pdf) and convert it back into a
+    # Dask DataFrame.
+    valid_id = pdf.index.values[1]
+    pdf.loc[valid_id, parquet_ensemble._flux_col] = pd.NA
+    parquet_ensemble._source = dd.from_pandas(pdf, npartitions=1)
+
+    # Sync the table and check that the number of objects decreased.
+    parquet_ensemble.dropna(1)
+    parquet_ensemble._sync_tables(keep_zero_entries=True)
+
+    new_objects_pdf = parquet_ensemble._object.compute()
+    assert len(new_objects_pdf.index) == len(old_objects_pdf.index)
+
+    # Check that all counts have stayed the same except the filtered index,
+    # which should now be all zeros.
+    for i in old_objects_pdf.index.values:
+        for c in new_objects_pdf.columns.values:
+            if i == valid_id:
+                assert new_objects_pdf.loc[i, c] == 0
+            else:
+                assert new_objects_pdf.loc[i, c] == old_objects_pdf.loc[i, c]
 
 
 def test_prune(parquet_ensemble):


### PR DESCRIPTION
This PR addresses issue #75. Creates an optional parameter that allows `_generate_object_table` to keep any object ids are no longer in the `_source` table but were previously in the `_object` table. It populates all counts for these objects with zero.