### PR TITLE
Allow users to not pass timestamps into SF2 function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest-cov", # Used to report total code coverage
     "pre-commit", # Used to run checks before finalizing a git commit
     "nbconvert", # Needed for pre-commit check to clear output from Python notebooks
+    "nbsphinx", # Used to integrate Python notebooks into Sphinx documentation
     "sphinx==6.1.3", # Used to automatically generate documentation
     "sphinx_rtd_theme==1.2.0", # Used to render documentation
     "sphinx-autoapi==2.0.1", # Used to automatically generate api documentation

--- a/src/lsstseries/analysis/structurefunction2.py
+++ b/src/lsstseries/analysis/structurefunction2.py
@@ -13,7 +13,8 @@ def calc_sf2(
     lc_id : 'numpy.ndarray' (N,)
         Array of lightcurve ids per data point.
     time : `numpy.ndarray` (N,)
-        Array of times when measurements were taken.
+        Array of times when measurements were taken. If all array values are
+        `None`, then equidistant times between measurements are assumed.
     flux : `numpy.ndarray` (N,)
         Array of flux/magnitude measurements.
     err : `numpy.ndarray` (N,)
@@ -69,6 +70,13 @@ def calc_sf2(
 
             # Mask on band
             times = np.array(time)[band_mask]
+
+            # if times are all `None`, we assume equidistant times between
+            # measurements. To do so, we'll create an array of integers
+            # from 0 to N where N is the number of flux values for this band.
+            if np.all(np.equal(times, None)):
+                times = np.arange(sum(band_mask), dtype=int)
+
             fluxes = np.array(flux)[band_mask]
             errors = np.array(err)[band_mask]
             lc_ids = np.array(lc_id)[band_mask]

--- a/src/lsstseries/analysis/structurefunction2.py
+++ b/src/lsstseries/analysis/structurefunction2.py
@@ -12,9 +12,10 @@ def calc_sf2(
     ----------
     lc_id : 'numpy.ndarray' (N,)
         Array of lightcurve ids per data point.
-    time : `numpy.ndarray` (N,)
+    time : `numpy.ndarray` (N,) or None
         Array of times when measurements were taken. If all array values are
-        `None`, then equidistant times between measurements are assumed.
+        `None` or if a scalar `None` is provided, then equidistant time between
+        measurements is assumed.
     flux : `numpy.ndarray` (N,)
         Array of flux/magnitude measurements.
     err : `numpy.ndarray` (N,)
@@ -69,11 +70,20 @@ def calc_sf2(
             band_mask = band == b
 
             # Mask on band
-            times = np.array(time)[band_mask]
+            times = None
 
-            # if times are all `None`, we assume equidistant times between
-            # measurements. To do so, we'll create an array of integers
-            # from 0 to N where N is the number of flux values for this band.
+            # if the user passed in a scalar `None` value, create a numpy array
+            # with a single `None` element. Otherwise assume the user passed an
+            # array of timestamps to be masked with `band_mask`.
+            # Note: some or all timestamps could be `None`.
+            if time is None:
+                times = np.array(None)
+            else:
+                times = np.array(time)[band_mask]
+
+            # if all elements in `times` are `None`, we assume equidistant times
+            # between measurements. To do so, we'll create an array of integers
+            # from 0 to N-1 where N is the number of flux values for this band.
             if np.all(np.equal(times, None)):
                 times = np.arange(sum(band_mask), dtype=int)
 

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -189,3 +189,60 @@ def test_sf2_base_case_time_as_none_array():
 
     assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_sf2_base_case_time_as_none_scalar():
+    """
+    Call calc_sf2 directly. Pass a scalar `None` for time.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = None
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_y))
+
+    res = analysis.calc_sf2(
+        lc_id=lc_id,
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        band=test_band,
+        bins=None,
+        band_to_calc=None,
+        combine=False,
+        method="size",
+        sthresh=100,
+    )
+
+    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_sf2_base_case_string_for_band_to_calc():
+    """
+    Base test case accessing calc_sf2 directly. Pass a string for band_to_calc.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_y))
+    test_band_to_calc = "r"
+
+    res = analysis.calc_sf2(
+        lc_id=lc_id,
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        band=test_band,
+        bins=None,
+        band_to_calc=test_band_to_calc,
+        combine=False,
+        method="size",
+        sthresh=100,
+    )
+
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -51,6 +51,56 @@ def test_sf2_timeseries(lc_id):
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
+def test_sf2_timeseries_without_timestamps():
+    """
+    Test of structure function squared function for a known return value without
+    providing timestamp values
+    """
+
+    test_t = None
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+
+    test_dict = {
+        "time": test_t,
+        "flux": test_y,
+        "flux_err": test_yerr,
+        "band": ["r"] * len(test_y),
+    }
+    timeseries = TimeSeries()
+    timeseries.meta["id"] = 1
+    test_series = timeseries.from_dict(data_dict=test_dict)
+    res = test_series.sf2(sthresh=100)
+
+    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_sf2_timeseries_with_all_none_timestamps():
+    """
+    Test of structure function squared function for a known return value without
+    providing timestamp values
+    """
+
+    test_t = [None, None, None, None, None, None, None, None]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+
+    test_dict = {
+        "time": test_t,
+        "flux": test_y,
+        "flux_err": test_yerr,
+        "band": ["r"] * len(test_y),
+    }
+    timeseries = TimeSeries()
+    timeseries.meta["id"] = 1
+    test_series = timeseries.from_dict(data_dict=test_dict)
+    res = test_series.sf2(sthresh=100)
+
+    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+
 def test_dt_bins():
     """
     Test that the binning routines return the expected properties
@@ -83,3 +133,59 @@ def test_dt_bins():
 
     bins = analysis.structurefunction2._bin_dts(dts, method="loglength")
     assert len(bins) == 11
+
+
+def test_sf2_base_case():
+    """
+    Base test case accessing calc_sf2 directly. Does not make use of TimeSeries
+    or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_y))
+
+    res = analysis.calc_sf2(
+        lc_id=lc_id,
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        band=test_band,
+        bins=None,
+        band_to_calc=None,
+        combine=False,
+        method="size",
+        sthresh=100,
+    )
+
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_sf2_base_case_time_as_none_array():
+    """
+    Call calc_sf2 directly. Pass time array of all `None`s.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [None, None, None, None, None, None, None, None]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_y))
+
+    res = analysis.calc_sf2(
+        lc_id=lc_id,
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        band=test_band,
+        bins=None,
+        band_to_calc=None,
+        combine=False,
+        method="size",
+        sthresh=100,
+    )
+
+    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)


### PR DESCRIPTION
The actual logic here is relatively small (and so hopefully safe). Most of this PR is adding unit tests. 