### PR TITLE
Allow user to pass `None`, scalar, or array as `err` parameter.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,12 +81,15 @@ repos:
         exclude_types: [file, symlink]
         args:
           [
-            "-T", # Show full trace back on exception
-            "-E", # Don't use saved env. always read all files.
-            "-b", # Flag to select which builder to use
-            "html", # Use the HTML builder
-            "-d", # Flag for cached environment and doctrees
-            "docs/build/doctrees", # directory
+            "-M", # Run sphinx in make mode, so we can use -D flag later
+                  # Note: -M requires next 3 args to be builder, source, output
+            "html", # Specify builder
             "./docs", # Source directory of documents
-            "docs/build/html", # Output directory for rendered documents.
+            "./_readthedocs", # Output directory for rendered documents
+            "-T", # Show full trace back on exception
+            "-E", # Don't use saved env; always read all files
+            "-d", # Flag for cached environment and doctrees
+            "./docs/_build/doctrees", # Directory
+            "-D", # Flag to override settings in conf.py
+            "exclude_patterns=notebooks/*", # Exclude our notebooks from pre-commit
           ]

--- a/src/lsstseries/analysis/structurefunction2.py
+++ b/src/lsstseries/analysis/structurefunction2.py
@@ -18,8 +18,10 @@ def calc_sf2(
         measurements is assumed.
     flux : `numpy.ndarray` (N,)
         Array of flux/magnitude measurements.
-    err : `numpy.ndarray` (N,)
-        Array of associated flux/magnitude errors.
+    err : `numpy.ndarray` (N,), `float`, or `None`
+        Array of associated flux/magnitude errors. If a scalar value is provided
+        we assume that error for all measurements. If `None` is provided, we
+        assume all errors are 0.
     band : `numpy.ndarray` (N,)
         Array of associated band labels,
     bins : `numpy.ndarray`
@@ -87,8 +89,21 @@ def calc_sf2(
             if np.all(np.equal(times, None)):
                 times = np.arange(sum(band_mask), dtype=int)
 
+            errors = None
+            # assume all errors are 0 if `None` is provided
+            if err is None:
+                errors = np.zeros(sum(band_mask))
+
+            # assume the same error for all measurements if a scalar value is
+            # provided
+            elif np.isscalar(err):
+                errors = np.ones(sum(band_mask)) * err
+
+            # otherwise assume one error value per measurement
+            else:
+                errors = np.array(err)[band_mask]
+
             fluxes = np.array(flux)[band_mask]
-            errors = np.array(err)[band_mask]
             lc_ids = np.array(lc_id)[band_mask]
 
             # Create stacks of critical quantities, indexed by id

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -135,6 +135,19 @@ def test_dt_bins():
     assert len(bins) == 11
 
 
+def test_dt_bins_raises_exception():
+    """
+    Test _bin_dts to make sure it raises an exception for an unknown method.
+    """
+    # Test on some known data.
+    dts = np.array([(201.0 - i) for i in range(2)])
+    test_method = "not_a_real_method"
+
+    with pytest.raises(ValueError) as excinfo:
+        _ = analysis.structurefunction2._bin_dts(dts, method=test_method)
+    assert "Method 'not_a_real_method' not recognized"
+
+
 def test_sf2_base_case():
     """
     Base test case accessing calc_sf2 directly. Does not make use of TimeSeries
@@ -246,3 +259,59 @@ def test_sf2_base_case_string_for_band_to_calc():
 
     assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_sf2_base_case_error_as_scalar():
+    """
+    Base test case accessing calc_sf2 directly. Provides a scalar value for
+    error. Does not make use of TimeSeries or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = 0.1
+    test_band = np.array(["r"] * len(test_y))
+
+    res = analysis.calc_sf2(
+        lc_id=lc_id,
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        band=test_band,
+        bins=None,
+        band_to_calc=None,
+        combine=False,
+        method="size",
+        sthresh=100,
+    )
+
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.152482, rel=0.001)
+
+
+def test_sf2_base_case_error_as_none():
+    """
+    Base test case accessing calc_sf2 directly. Provides `None` for error.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = None
+    test_band = np.array(["r"] * len(test_y))
+
+    res = analysis.calc_sf2(
+        lc_id=lc_id,
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        band=test_band,
+        bins=None,
+        band_to_calc=None,
+        combine=False,
+        method="size",
+        sthresh=100,
+    )
+
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.172482, rel=0.001)


### PR DESCRIPTION
This PR updates `calc_sf2` to support `None`, scalar, and arrays of values as input to the `err` parameter. When `None` is passed, we'll assume all measurement errors are 0. When a scalar is passed in, we'll assume the same error for all measurements. When an array is provided, we assume a distinct error for each measurement. 

There are a couple of ways to potentially optimize this that I didn't pursue, because I can imagine a refactor in the works soon. Namely, instead of generating arrays of either 0 or a repeated scalar value, we could pass a flag to the inner functions, signaling when to avoid extra work specifically for the case of `None` or scalar inputs. 

Also, as was mentioned by @dougbrn in a comment here: https://github.com/lincc-frameworks/lsstseries/pull/86#discussion_r1170499483 The new functionality introduced in this PR won't be accessible to `Ensemble`s via either `Ensemble.batch` or `Ensemble.sf2`, nor to `TimeSeries.sf2` until we modify they way those classes interact with this analysis function.