### PR TITLE
Adding support to allow users to pass `None` for lc_id and/or band

### DIFF
--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -5,10 +5,6 @@ import numpy as np
 
 from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
 
-# from lsstseries.analysis.structure_function_argument_containers.structure_function_argument_container import (
-#     StructureFunctionArgumentContainer,
-# )
-
 
 class StructureFunctionCalculator(ABC):
     """This is the base class from which all other Structure Function calculator

--- a/src/lsstseries/analysis/structure_function/basic/calculator.py
+++ b/src/lsstseries/analysis/structure_function/basic/calculator.py
@@ -6,13 +6,6 @@ from scipy.stats import binned_statistic
 from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
 from lsstseries.analysis.structure_function.base_calculator import StructureFunctionCalculator
 
-# from lsstseries.analysis.structure_function_argument_containers.structure_function_argument_container import (
-#     StructureFunctionArgumentContainer,
-# )
-# from lsstseries.analysis.structure_function_calculators.structure_function_calculator import (
-#     StructureFunctionCalculator,
-# )
-
 
 class BasicStructureFunctionCalculator(StructureFunctionCalculator):
     """

--- a/src/lsstseries/analysis/structurefunction2.py
+++ b/src/lsstseries/analysis/structurefunction2.py
@@ -53,9 +53,13 @@ def calc_sf2(time, flux, err=None, band=None, lc_id=None, sf_method="basic", arg
     # `argument_container` and use the values found there.
     if band is None:
         band = argument_container.band
+    if band is None:  # Still None after assignment?
+        band = np.full(len(flux), "none")
 
     if lc_id is None:
         lc_id = argument_container.lc_id
+    if lc_id is None:  # Still None after assignment?
+        lc_id = np.zeros(len(flux))
 
     if sf_method == "basic":
         sf_method = argument_container.sf_method
@@ -91,7 +95,7 @@ def calc_sf2(time, flux, err=None, band=None, lc_id=None, sf_method="basic", arg
             # with a single `None` element. Otherwise assume the user passed an
             # array of timestamps to be masked with `band_mask`.
             # Note: some or all timestamps could be `None`.
-            if time is None:
+            if time is None or argument_container.ignore_timestamps:
                 times = np.array(None)
             else:
                 times = np.array(time)[band_mask]

--- a/src/lsstseries/analysis/structurefunction2.py
+++ b/src/lsstseries/analysis/structurefunction2.py
@@ -51,10 +51,7 @@ def calc_sf2(time, flux, err=None, band=None, lc_id=None, sf_method="basic", arg
     # `argument_container`. If any of these arguments are provided with
     # non-default values, we'll use those. Otherwise, we'll look inside
     # `argument_container` and use the values found there.
-    if band is None:
-        band = argument_container.band
-    if band is None:  # Still None after assignment?
-        band = np.full(len(flux), "none")
+    band = _validate_band(band, flux, argument_container)
 
     if lc_id is None:
         lc_id = argument_container.lc_id
@@ -89,36 +86,9 @@ def calc_sf2(time, flux, err=None, band=None, lc_id=None, sf_method="basic", arg
             band_mask = band == b
 
             # Mask on band
-            times = None
+            times = _extract_time(time=time, band_mask=band_mask, argument_container=argument_container)
 
-            # if the user passed in a scalar `None` value, create a numpy array
-            # with a single `None` element. Otherwise assume the user passed an
-            # array of timestamps to be masked with `band_mask`.
-            # Note: some or all timestamps could be `None`.
-            if time is None or argument_container.ignore_timestamps:
-                times = np.array(None)
-            else:
-                times = np.array(time)[band_mask]
-
-            # if all elements in `times` are `None`, we assume equidistant times
-            # between measurements. To do so, we'll create an array of integers
-            # from 0 to N-1 where N is the number of flux values for this band.
-            if np.all(np.equal(times, None)):
-                times = np.arange(sum(band_mask), dtype=int)
-
-            errors = None
-            # assume all errors are 0 if `None` is provided
-            if err is None:
-                errors = np.zeros(sum(band_mask))
-
-            # assume the same error for all measurements if a scalar value is
-            # provided
-            elif np.isscalar(err):
-                errors = np.ones(sum(band_mask)) * err
-
-            # otherwise assume one error value per measurement
-            else:
-                errors = np.array(err)[band_mask]
+            errors = _extract_error(err=err, band_mask=band_mask)
 
             fluxes = np.array(flux)[band_mask]
             lc_ids = np.array(lc_id)[band_mask]
@@ -149,3 +119,90 @@ def calc_sf2(time, flux, err=None, band=None, lc_id=None, sf_method="basic", arg
         {"lc_id": idstack, "band": np.hstack(bands), "dt": np.hstack(dts), "sf2": np.hstack(sf2s)}
     )
     return sf2_df
+
+
+def _validate_band(band, flux, argument_container):
+    # if the input argument `band` is None, check the value of `argument_container.band`
+    if band is None:
+        band = argument_container.band
+
+    # if band is still `None`, create a fake array of bands. We'll use numpy int8
+    # values to use as little memory as possible.
+    if band is None:
+        band = np.full(len(flux), 1, dtype=np.int8)
+
+    if len(band) != len(flux):
+        raise (
+            ValueError,
+            "Value of `band` should be `None` or array with length equal length of `flux` array.",
+        )
+
+    return band
+
+
+def _extract_time(time, band_mask, argument_container):
+    """This will process the input time values, apply a band mask and return a
+    numpy array of timestamps.
+
+    Parameters
+    ----------
+    time : `numpy.ndarray` (N,) or `None`
+        Array of times when measurements were taken. If all array values are
+        `None` or if a scalar `None` is provided, then equidistant time between
+        measurements is assumed.
+    band_mask : `numpy mask` (N,)
+        Array of associated band labels, by default None
+    argument_container : StructureFunctionArgumentContainer, optional
+        Container object for additional configuration options, by default None.
+    """
+
+    times = None
+
+    # if the user passed in a scalar `None` value, or if explicitly ignoring
+    # timestamps using the argument_container flag, create a numpy array
+    # with a single `None` element. Otherwise assume the user passed an
+    # array of timestamps to be masked with `band_mask`.
+    # Note: some or all timestamps could be `None`.
+    if time is None or argument_container.ignore_timestamps:
+        times = np.array(None)
+    else:
+        times = np.array(time)[band_mask]
+
+    # if all elements in `times` are `None`, we assume equidistant times
+    # between measurements. To do so, we'll create an array of integers
+    # from 0 to N-1 where N is the number of flux values for this band.
+    if np.all(np.equal(times, None)):
+        times = np.arange(sum(band_mask), dtype=int)
+
+    return times
+
+
+def _extract_error(err, band_mask):
+    """Process the input err value(s), apply a band_mask, and return a numpy
+    array of error values.
+
+    Parameters
+    ----------
+    err : `numpy.ndarray` (N,), `float`, or `None`
+        Array of associated flux/magnitude errors. If a scalar value is provided
+        we assume that error for all measurements. If `None` is provided, we
+        assume all errors are 0. By default None
+    band_mask : `numpy mask` (N,)
+        Array of associated band labels, by default None
+    """
+
+    errors = None
+    # assume all errors are 0 if `None` is provided
+    if err is None:
+        errors = np.zeros(sum(band_mask))
+
+    # assume the same error for all measurements if a scalar value is
+    # provided
+    elif np.isscalar(err):
+        errors = np.ones(sum(band_mask)) * err
+
+    # otherwise assume one error value per measurement
+    else:
+        errors = np.array(err)[band_mask]
+
+    return errors

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -1,11 +1,11 @@
 import time
+import warnings
 
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pyvo as vo
 from dask.distributed import Client
-import warnings
 
 from .analysis.structure_function import SF_METHODS
 from .analysis.structurefunction2 import calc_sf2

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -318,3 +318,26 @@ def test_sf2_least_possible_infomation_constant_flux():
 
     assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.0, rel=0.001)
+
+
+@pytest.mark.skip
+def test_sf2_flux_and_band_different_lengths():
+    """
+    Base test case accessing calc_sf2 directly. Flux and band are different
+    lengths. Expect an exception to be raised.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2, 0.3]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_t))
+
+    with pytest.raises(ValueError) as execinfo:
+        analysis.calc_sf2(
+            time=test_t,
+            flux=test_y,
+            err=test_yerr,
+            band=test_band,
+            lc_id=lc_id,
+        )

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -296,9 +296,6 @@ def test_sf2_least_possible_information():
         flux=test_y,
     )
 
-    # assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
-    # assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
-
     assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.172482, rel=0.001)
 
@@ -312,9 +309,6 @@ def test_sf2_least_possible_information_constant_flux():
     test_y = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
 
     res = analysis.calc_sf2(time=None, flux=test_y)
-
-    # assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
-    # assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
     assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.0, rel=0.001)

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -239,3 +239,82 @@ def test_sf2_base_case_error_as_none():
 
     assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.172482, rel=0.001)
+
+
+def test_sf2_no_lightcurve_ids():
+    """
+    Base test case accessing calc_sf2 directly. Pass no lightcurve ids.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_y))
+
+    res = analysis.calc_sf2(
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        band=test_band,
+    )
+
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_sf2_no_band_information():
+    """
+    Base test case accessing calc_sf2 directly. Pass no band information
+    Does not make use of TimeSeries or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+
+    res = analysis.calc_sf2(
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        lc_id=lc_id,
+    )
+
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_sf2_least_possible_infomation():
+    """
+    Base test case accessing calc_sf2 directly. Pass time as None and flux, but
+    nothing else.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+
+    res = analysis.calc_sf2(
+        time=None,
+        flux=test_y,
+    )
+
+    # assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    # assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.172482, rel=0.001)
+
+
+def test_sf2_least_possible_infomation_constant_flux():
+    """
+    Base test case accessing calc_sf2 directly. Pass time as None and identical
+    flux values, but nothing else.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    test_y = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+
+    res = analysis.calc_sf2(time=None, flux=test_y)
+
+    # assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    # assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+
+    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.0, rel=0.001)

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -283,7 +283,7 @@ def test_sf2_no_band_information():
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
-def test_sf2_least_possible_infomation():
+def test_sf2_least_possible_information():
     """
     Base test case accessing calc_sf2 directly. Pass time as None and flux, but
     nothing else.
@@ -303,7 +303,7 @@ def test_sf2_least_possible_infomation():
     assert res["sf2"][0] == pytest.approx(0.172482, rel=0.001)
 
 
-def test_sf2_least_possible_infomation_constant_flux():
+def test_sf2_least_possible_information_constant_flux():
     """
     Base test case accessing calc_sf2 directly. Pass time as None and identical
     flux values, but nothing else.
@@ -320,7 +320,7 @@ def test_sf2_least_possible_infomation_constant_flux():
     assert res["sf2"][0] == pytest.approx(0.0, rel=0.001)
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 def test_sf2_flux_and_band_different_lengths():
     """
     Base test case accessing calc_sf2 directly. Flux and band are different
@@ -341,3 +341,206 @@ def test_sf2_flux_and_band_different_lengths():
             band=test_band,
             lc_id=lc_id,
         )
+
+    assert "same length" in str(execinfo.value)
+
+
+def test_sf2_flux_and_lc_id_different_lengths():
+    """
+    Base test case accessing calc_sf2 directly. Flux and lc_id are different
+    lengths. Expect an exception to be raised.
+    Does not make use of TimeSeries or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1, 2]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_t))
+
+    with pytest.raises(ValueError) as execinfo:
+        analysis.calc_sf2(
+            time=test_t,
+            flux=test_y,
+            err=test_yerr,
+            band=test_band,
+            lc_id=lc_id,
+        )
+
+    assert "same length" in str(execinfo.value)
+
+
+def test_create_arg_container_without_arg_container():
+    """Base case, no argument container provided, expect a default argument_container
+    to be created.
+    """
+
+    test_sf_method = "basic"
+    default_arg_container = StructureFunctionArgumentContainer()
+
+    output_arg_container = analysis.structurefunction2._create_arg_container_if_needed(test_sf_method, None)
+    assert default_arg_container.sf_method == output_arg_container.sf_method
+    assert default_arg_container.ignore_timestamps == output_arg_container.ignore_timestamps
+
+
+def test_create_arg_container_with_arg_container():
+    """Base case, with an argument container provided,
+    expect that the argument container will be passed through, untouched.
+    """
+
+    test_sf_method = "basic"
+    default_arg_container = StructureFunctionArgumentContainer()
+
+    # set one property to a non-default value
+    default_arg_container.ignore_timestamps = True
+
+    output_arg_container = analysis.structurefunction2._create_arg_container_if_needed(
+        test_sf_method, default_arg_container
+    )
+    assert default_arg_container.sf_method == output_arg_container.sf_method
+    assert default_arg_container.ignore_timestamps == output_arg_container.ignore_timestamps
+
+
+def test_validate_band_with_band_value():
+    """Base case where band would be passed in as a non-default value.
+    An argument_container is also provided with a different value. We expect
+    that the `band` would be the resulting output.
+    """
+
+    input_band = ["r"]
+    input_flux = [1]
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.band = ["b"]
+
+    output_band = analysis.structurefunction2._validate_band(input_band, input_flux, arg_container)
+
+    assert output_band == input_band
+
+
+def test_validate_band_with_arg_container_band_value():
+    """Base case where band would be passed in as a default (`None`) value.
+    An argument_container is also provided with an actual value. We expect
+    that the `arg_container.band` would be the resulting output.
+    """
+
+    input_band = None
+    input_flux = [1]
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.band = ["b"]
+
+    output_band = analysis.structurefunction2._validate_band(input_band, input_flux, arg_container)
+
+    assert output_band == arg_container.band
+
+
+def test_validate_band_with_no_input_values():
+    """Base case where band is not provided in any location. Expected output is
+    an array of 0s equal in length to the input_flux array.
+    """
+
+    input_band = None
+    input_flux = [1]
+    arg_container = StructureFunctionArgumentContainer()
+    expected_output = np.zeros(len(input_flux), dtype=np.int8)
+
+    output_band = analysis.structurefunction2._validate_band(input_band, input_flux, arg_container)
+
+    assert output_band == expected_output
+
+
+def test_validate_band_with_band_value_wrong_length():
+    """Band will be passed in, but will be a different length than the input flux."""
+
+    input_band = ["r"]
+    input_flux = [1, 2]
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.band = ["b"]
+
+    with pytest.raises(ValueError) as execinfo:
+        analysis.structurefunction2._validate_band(input_band, input_flux, arg_container)
+
+    assert "same length" in str(execinfo.value)
+
+
+def test_validate_lightcurve_with_lc_value():
+    """Base case where lc_id would be passed in as a non-default value.
+    An argument_container is also provided with a different value. We expect
+    that the `lc_id` would be the resulting output.
+    """
+
+    input_lc_id = [100]
+    input_flux = [1]
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.lc_id = [333]
+
+    output_lc_id = analysis.structurefunction2._validate_lightcurve_id(input_lc_id, input_flux, arg_container)
+
+    assert output_lc_id == input_lc_id
+
+
+def test_validate_lightcurve_with_arg_container_lc_value():
+    """Base case where lc_id would be passed in as a default (`None`) value.
+    An argument_container is also provided with an actual value. We expect
+    that the `arg_container.lc_id` would be the resulting output.
+    """
+
+    input_lc_id = None
+    input_flux = [1]
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.lc_id = [333]
+
+    output_lc_id = analysis.structurefunction2._validate_lightcurve_id(input_lc_id, input_flux, arg_container)
+
+    assert output_lc_id == arg_container.lc_id
+
+
+def test_validate_lightcurve_with_no_input_values():
+    """Base case where lc_id is not provided in any location. Expected output is
+    an array of 0s equal in length to the input_flux array.
+    """
+
+    input_lc_id = None
+    input_flux = [1]
+    arg_container = StructureFunctionArgumentContainer()
+    expected_output = np.zeros(len(input_flux), dtype=np.int8)
+
+    output_lc_id = analysis.structurefunction2._validate_lightcurve_id(input_lc_id, input_flux, arg_container)
+
+    assert output_lc_id == expected_output
+
+
+def test_validate_band_with_band_value_wrong_length():
+    """Lightcurve id will be passed in, but will be a different length than the input flux."""
+
+    input_lc_id = [100]
+    input_flux = [1, 2]
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.lc_id = [333]
+
+    with pytest.raises(ValueError) as execinfo:
+        analysis.structurefunction2._validate_band(input_lc_id, input_flux, arg_container)
+
+    assert "same length" in str(execinfo.value)
+
+
+def test_validate_sf_method_base():
+    """Will pass in "basic" and expect "basic" and output."""
+
+    input_sf_method = "basic"
+    arg_container = StructureFunctionArgumentContainer()
+
+    output_sf_method = analysis.structurefunction2._validate_sf_method(input_sf_method, arg_container)
+
+    assert input_sf_method == output_sf_method
+
+
+def test_validate_sf_method_raises_for_unknown_method():
+    """Make sure that we raise an exception when an unknown sf_method is provided."""
+
+    input_sf_method = "basic"
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.sf_method = "bogus_method"
+
+    with pytest.raises(ValueError) as execinfo:
+        analysis.structurefunction2._validate_sf_method(input_sf_method, arg_container)
+
+    assert "Unknown" in str(execinfo.value)


### PR DESCRIPTION
The vast majority of this PR is organizing argument validation in `structurefunction2.py`. You'll see calls to functions named `_validate_<arg>`. In each of those we'll take a look at the input arguments and possibly the values found in argument_container as well, and take the one with the highest priority. 

Additionally we may do some comparison checks and raise exceptions if the inputs are not well formed. i.e. number of elements in `band` doesn't match number of elements in `flux` arrays.

But to address the title of the PR, this work also allows users:
- Pass nothing at all for `lc_id` (`None` will be the default)
- Pass `None` for `lc_id`
- Pass an array for `lc_id`
- Pass `lc_id` inside of the argument container

and 
- Pass nothing at all for `band` (`None` will be the default)
- Pass `None` for `band`
- Pass an array for `band`
- Pass `band` inside of the argument container

