### PR TITLE
Implementing Macleod 2012 SF calculator method

### DIFF
--- a/src/lsstseries/analysis/structure_function/__init__.py
+++ b/src/lsstseries/analysis/structure_function/__init__.py
@@ -1,6 +1,7 @@
 from .base_argument_container import StructureFunctionArgumentContainer
 from .base_calculator import StructureFunctionCalculator
 from .basic.calculator import BasicStructureFunctionCalculator
+from .iqr.calculator import IqrStructureFunctionCalculator
 
 # This dynamically generates the dictionary of all available subclasses of the
 # StructureFunctionCalculator. It will have the form `{"unique_name" : class}`.

--- a/src/lsstseries/analysis/structure_function/__init__.py
+++ b/src/lsstseries/analysis/structure_function/__init__.py
@@ -2,6 +2,7 @@ from .base_argument_container import StructureFunctionArgumentContainer
 from .base_calculator import StructureFunctionCalculator
 from .basic.calculator import BasicStructureFunctionCalculator
 from .iqr.calculator import IqrStructureFunctionCalculator
+from .macleod_2012.calculator import Macleod2012StructureFunctionCalculator
 
 # This dynamically generates the dictionary of all available subclasses of the
 # StructureFunctionCalculator. It will have the form `{"unique_name" : class}`.

--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -14,9 +14,9 @@ class StructureFunctionCalculator(ABC):
 
     def __init__(
         self,
-        time: List[float],
-        flux: List[float],
-        err: List[float],
+        time: List[List[float]],
+        flux: List[List[float]],
+        err: List[List[float]],
         argument_container: StructureFunctionArgumentContainer,
     ):
         self._time = time
@@ -83,6 +83,28 @@ class StructureFunctionCalculator(ABC):
 
         else:
             raise ValueError(f"Method '{self._binning_method}' not recognized")
+
+    # def _validate_time_input(self, time):
+    #     """_summary_
+
+    #     Parameters
+    #     ----------
+    #     time : _type_
+    #         _description_
+
+    #     Returns
+    #     -------
+    #     _type_
+    #         _description_
+    #     """
+
+    #     if type(time) != np.ndarray:
+    #         raise TypeError("Expected numpy array")
+
+    #     if time.ndim != 2:
+    #         raise TypeError("Expected 2 dimensional input")
+
+    #     return time
 
     @staticmethod
     @abstractmethod

--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -84,28 +84,6 @@ class StructureFunctionCalculator(ABC):
         else:
             raise ValueError(f"Method '{self._binning_method}' not recognized")
 
-    # def _validate_time_input(self, time):
-    #     """_summary_
-
-    #     Parameters
-    #     ----------
-    #     time : _type_
-    #         _description_
-
-    #     Returns
-    #     -------
-    #     _type_
-    #         _description_
-    #     """
-
-    #     if type(time) != np.ndarray:
-    #         raise TypeError("Expected numpy array")
-
-    #     if time.ndim != 2:
-    #         raise TypeError("Expected 2 dimensional input")
-
-    #     return time
-
     @staticmethod
     @abstractmethod
     def name_id() -> str:

--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -14,9 +14,9 @@ class StructureFunctionCalculator(ABC):
 
     def __init__(
         self,
-        time: List[List[float]],
-        flux: List[List[float]],
-        err: List[List[float]],
+        time: np.ndarray,
+        flux: np.ndarray,
+        err: np.ndarray,
         argument_container: StructureFunctionArgumentContainer,
     ):
         self._time = time

--- a/src/lsstseries/analysis/structure_function/basic/calculator.py
+++ b/src/lsstseries/analysis/structure_function/basic/calculator.py
@@ -16,9 +16,9 @@ class BasicStructureFunctionCalculator(StructureFunctionCalculator):
 
     def __init__(
         self,
-        time: List[float],
-        flux: List[float],
-        err: List[float],
+        time: List[List[float]],
+        flux: List[List[float]],
+        err: List[List[float]],
         argument_container: StructureFunctionArgumentContainer,
     ):
         # The only work done in the __init__ method should be input argument

--- a/src/lsstseries/analysis/structure_function/iqr/calculator.py
+++ b/src/lsstseries/analysis/structure_function/iqr/calculator.py
@@ -1,0 +1,75 @@
+from typing import List
+
+import numpy as np
+
+from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
+from lsstseries.analysis.structure_function.base_calculator import StructureFunctionCalculator
+
+# For details see Kozlowski 16 Equation 10: https://arxiv.org/abs/1604.05858
+COEF_CONVERSION_TO_SIGMA = 0.741
+
+
+class IqrStructureFunctionCalculator(StructureFunctionCalculator):
+    """This class implements the structure function calculation described in
+    Equation 10 of Kozlowski 16: https://arxiv.org/abs/1604.05858
+
+    SF_obs(deltaT) = 0.741 * IQR
+
+    Where `IQR` is the interquartile range between 25% and 75% of the sorted
+    (y(t) - y(t+delta_t)) distribution.
+    """
+
+    def __init__(
+        self,
+        time: List[List[float]],
+        flux: List[List[float]],
+        err: List[List[float]],
+        argument_container: StructureFunctionArgumentContainer,
+    ):
+        super().__init__(time, flux, err, argument_container)
+
+    def calculate(self):
+        sfs_all = []
+        t_all = None
+        all_d_fluxes = []
+        for lc_idx in range(len(self._time)):
+            lc_times = self._time[lc_idx]
+            lc_fluxes = self._flux[lc_idx]
+
+            # mask out any nan values
+            t_mask = np.isnan(lc_times)
+            f_mask = np.isnan(lc_fluxes)
+            lc_mask = np.logical_or(t_mask, f_mask)
+
+            lc_times = lc_times[~lc_mask]
+            lc_fluxes = lc_fluxes[~lc_mask]
+
+            # compute difference of times
+            dt_matrix = lc_times.reshape((1, lc_times.size)) - lc_times.reshape((lc_times.size, 1))
+
+            # compute difference of fluxes, keep only where difference in time > 0
+            df_matrix = lc_fluxes.reshape((1, lc_fluxes.size)) - lc_fluxes.reshape((lc_fluxes.size, 1))
+            d_fluxes = df_matrix[dt_matrix > 0].flatten()
+
+            # expect all_d_fluxes to have shape = (num_lightcurves, N)
+            all_d_fluxes.append(d_fluxes)
+
+        # treat all data as a single light curve
+        if self._argument_container.combine:
+            # expect all_d_fluxes to have shape = (1, N)
+            all_d_fluxes = np.atleast_2d(np.hstack(all_d_fluxes))
+
+        # calculate interquartile range between 25% and 75%.
+        iqr = np.subtract(*np.percentile(all_d_fluxes, [75, 25], axis=1))
+
+        sfs_all = COEF_CONVERSION_TO_SIGMA * iqr
+
+        return t_all, sfs_all
+
+    @staticmethod
+    def name_id() -> str:
+        return "iqr"
+
+    @staticmethod
+    def expected_argument_container() -> type:
+        return StructureFunctionArgumentContainer

--- a/src/lsstseries/analysis/structure_function/iqr/calculator.py
+++ b/src/lsstseries/analysis/structure_function/iqr/calculator.py
@@ -1,12 +1,13 @@
 from typing import List
 
 import numpy as np
+from scipy.stats import binned_statistic
 
 from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
 from lsstseries.analysis.structure_function.base_calculator import StructureFunctionCalculator
 
 # For details see Kozlowski 16 Equation 10: https://arxiv.org/abs/1604.05858
-COEF_CONVERSION_TO_SIGMA = 0.741
+CONVERSION_TO_SIGMA = 0.741
 
 
 class IqrStructureFunctionCalculator(StructureFunctionCalculator):
@@ -29,8 +30,6 @@ class IqrStructureFunctionCalculator(StructureFunctionCalculator):
         super().__init__(time, flux, err, argument_container)
 
     def calculate(self):
-        sfs_all = []
-        t_all = None
         all_d_fluxes = []
         for lc_idx in range(len(self._time)):
             lc_times = self._time[lc_idx]
@@ -46,25 +45,74 @@ class IqrStructureFunctionCalculator(StructureFunctionCalculator):
 
             # compute difference of times
             dt_matrix = lc_times.reshape((1, lc_times.size)) - lc_times.reshape((lc_times.size, 1))
+            d_times = dt_matrix[dt_matrix > 0].flatten()
 
             # compute difference of fluxes, keep only where difference in time > 0
             df_matrix = lc_fluxes.reshape((1, lc_fluxes.size)) - lc_fluxes.reshape((lc_fluxes.size, 1))
             d_fluxes = df_matrix[dt_matrix > 0].flatten()
 
-            # expect all_d_fluxes to have shape = (num_lightcurves, N)
+            # build stack of times and fluxes
+            # `self._dts` and `all_d_fluxes` will have shape = (num_lightcurves, N)
+            self._dts.append(d_times)
             all_d_fluxes.append(d_fluxes)
 
-        # treat all data as a single light curve
-        if self._argument_container.combine:
-            # expect all_d_fluxes to have shape = (1, N)
-            all_d_fluxes = np.atleast_2d(np.hstack(all_d_fluxes))
+        # combining treats all lightcurves as one when calculating the structure function
+        if self._argument_container.combine and len(self._time) > 1:
+            self._dts = np.hstack(np.array(self._dts, dtype="object"))
+            all_d_fluxes = np.hstack(np.array(all_d_fluxes, dtype="object"))
 
+            # binning
+            if self._bins is None:
+                self._bin_dts(self._dts)
+
+            # structure function at specific dt
+            # the line below will throw error if the bins are not covering the whole range
+            sfs, bin_edgs, _ = binned_statistic(
+                self._dts, all_d_fluxes, statistic=self.calculate_iqr_sf2_statistic, bins=self._bins
+            )
+            return [(bin_edgs[0:-1] + bin_edgs[1:]) / 2], [sfs]
+
+        # Not combining calculates structure function for each light curve independently
+        else:
+            # may want to raise warning if len(times) <=1 and combine was set true
+            sfs_all = []
+            t_all = []
+            for lc_idx in range(len(self._dts)):
+                if len(self._dts[lc_idx]) > 1:
+                    # binning
+                    self._bin_dts(self._dts[lc_idx])
+                    sfs, bin_edgs, _ = binned_statistic(
+                        self._dts[lc_idx],
+                        all_d_fluxes[lc_idx],
+                        statistic=self.calculate_iqr_sf2_statistic,
+                        bins=self._bins,
+                    )
+                    sfs_all.append(sfs)
+                    t_all.append((bin_edgs[0:-1] + bin_edgs[1:]) / 2)
+                else:
+                    sfs_all.append(np.array([]))
+                    t_all.append(np.array([]))
+            return t_all, sfs_all
+
+    def calculate_iqr_sf2_statistic(self, input):
+        """For a given set of binned metrics (in this case delta fluxes) calculate
+        the interquartile range.
+
+        Parameters
+        ----------
+        input : `np.ndarray` (N,)
+            The delta flux values that correspond to a given delta time bin.
+
+        Returns
+        -------
+        float
+            Result of calculating Equation 10 of Kozlowski 16:
+            `SF(dt) = 0.741 * IQR`
+        """
         # calculate interquartile range between 25% and 75%.
-        iqr = np.subtract(*np.percentile(all_d_fluxes, [75, 25], axis=1))
+        iqr = np.subtract(*np.percentile(input, [75, 25]))
 
-        sfs_all = COEF_CONVERSION_TO_SIGMA * iqr
-
-        return t_all, sfs_all
+        return CONVERSION_TO_SIGMA * iqr
 
     @staticmethod
     def name_id() -> str:

--- a/src/lsstseries/analysis/structure_function/iqr/calculator.py
+++ b/src/lsstseries/analysis/structure_function/iqr/calculator.py
@@ -6,25 +6,28 @@ from scipy.stats import binned_statistic
 from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
 from lsstseries.analysis.structure_function.base_calculator import StructureFunctionCalculator
 
-# For details see Kozlowski 16 Equation 10: https://arxiv.org/abs/1604.05858
+# For details MacLeod et al. 2012, 2012ApJ...753..106M [https://arxiv.org/abs/1112.0679]
 CONVERSION_TO_SIGMA = 0.741
 
 
 class IqrStructureFunctionCalculator(StructureFunctionCalculator):
     """This class implements the structure function calculation described in
-    Equation 10 of Kozlowski 16: https://arxiv.org/abs/1604.05858
+    MacLeod et al. 2012, 2012ApJ...753..106M [https://arxiv.org/abs/1112.0679]
 
     SF_obs(deltaT) = 0.741 * IQR
 
     Where `IQR` is the interquartile range between 25% and 75% of the sorted
     (y(t) - y(t+delta_t)) distribution.
+
+    References:
+    Kozlowski 2016, 2016ApJ...826..118K [https://arxiv.org/abs/1604.05858]
     """
 
     def __init__(
         self,
-        time: List[List[float]],
-        flux: List[List[float]],
-        err: List[List[float]],
+        time: np.ndarray,
+        flux: np.ndarray,
+        err: np.ndarray,
         argument_container: StructureFunctionArgumentContainer,
     ):
         super().__init__(time, flux, err, argument_container)
@@ -106,7 +109,9 @@ class IqrStructureFunctionCalculator(StructureFunctionCalculator):
         Returns
         -------
         float
-            Result of calculating Equation 10 of Kozlowski 16:
+            Result of calculating defined in
+            MacLeod et al. 2012, 2012ApJ...753..106M [https://arxiv.org/abs/1112.0679]:
+
             `SF(dt) = 0.741 * IQR`
         """
         # calculate interquartile range between 25% and 75%.

--- a/src/lsstseries/analysis/structure_function/macleod_2012/calculator.py
+++ b/src/lsstseries/analysis/structure_function/macleod_2012/calculator.py
@@ -6,26 +6,29 @@ from scipy.stats import binned_statistic
 from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
 from lsstseries.analysis.structure_function.base_calculator import StructureFunctionCalculator
 
-# For details see Graham+ 16 Equation 10: https://arxiv.org/abs/1401.1785
+# For details MacLeod et al. 2012, 2012ApJ...753..106M [https://arxiv.org/abs/1112.0679]
 CONVERSION_TO_SIGMA = 0.74
 
 
 class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
     """This class implements the structure function calculation described in
-    (Macleod et al. 2012) of Graham+ 16: https://arxiv.org/abs/1401.1785
+    MacLeod et al. 2012, 2012ApJ...753..106M [https://arxiv.org/abs/1112.0679]
 
     SF_obs(delta_t) = 0.741 * IQR / sqrt(N-1)
 
     Where `IQR` is the interquartile range between 25% and 75% of the sorted
     (y(t) - y(t+delta_t)) distribution, and `N` is the number of delta_y values
     for a given delta_t bin.
+
+    References:
+    Graham et al. 2014, 2014MNRAS.439..703G [https://arxiv.org/abs/1401.1785]
     """
 
     def __init__(
         self,
-        time: List[List[float]],
-        flux: List[List[float]],
-        err: List[List[float]],
+        time: np.ndarray,
+        flux: np.ndarray,
+        err: np.ndarray,
         argument_container: StructureFunctionArgumentContainer,
     ):
         super().__init__(time, flux, err, argument_container)
@@ -122,7 +125,9 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
         Returns
         -------
         float
-            Result of calculating IQR part of (Macleod et al. 2012) of Graham+ 16:
+            Result of calculating IQR part of
+            MacLeod et al. 2012, 2012ApJ...753..106M [https://arxiv.org/abs/1112.0679]
+
             `0.74 * IQR`
         """
         # calculate interquartile range between 25% and 75%.

--- a/src/lsstseries/analysis/structure_function/macleod_2012/calculator.py
+++ b/src/lsstseries/analysis/structure_function/macleod_2012/calculator.py
@@ -1,0 +1,139 @@
+from typing import List
+
+import numpy as np
+from scipy.stats import binned_statistic
+
+from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
+from lsstseries.analysis.structure_function.base_calculator import StructureFunctionCalculator
+
+# For details see Graham+ 16 Equation 10: https://arxiv.org/abs/1401.1785
+CONVERSION_TO_SIGMA = 0.74
+
+
+class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
+    """This class implements the structure function calculation described in
+    (Macleod et al. 2012) of Graham+ 16: https://arxiv.org/abs/1401.1785
+
+    SF_obs(delta_t) = 0.741 * IQR / sqrt(N-1)
+
+    Where `IQR` is the interquartile range between 25% and 75% of the sorted
+    (y(t) - y(t+delta_t)) distribution, and `N` is the number of delta_y values
+    for a given delta_t bin.
+    """
+
+    def __init__(
+        self,
+        time: List[List[float]],
+        flux: List[List[float]],
+        err: List[List[float]],
+        argument_container: StructureFunctionArgumentContainer,
+    ):
+        super().__init__(time, flux, err, argument_container)
+
+    def calculate(self):
+        all_d_fluxes = []
+        for lc_idx in range(len(self._time)):
+            lc_times = self._time[lc_idx]
+            lc_fluxes = self._flux[lc_idx]
+
+            # mask out any nan values
+            t_mask = np.isnan(lc_times)
+            f_mask = np.isnan(lc_fluxes)
+            lc_mask = np.logical_or(t_mask, f_mask)
+
+            lc_times = lc_times[~lc_mask]
+            lc_fluxes = lc_fluxes[~lc_mask]
+
+            # compute difference of times
+            dt_matrix = lc_times.reshape((1, lc_times.size)) - lc_times.reshape((lc_times.size, 1))
+            d_times = dt_matrix[dt_matrix > 0].flatten()
+
+            # compute difference of fluxes, keep only where difference in time > 0
+            df_matrix = lc_fluxes.reshape((1, lc_fluxes.size)) - lc_fluxes.reshape((lc_fluxes.size, 1))
+            d_fluxes = df_matrix[dt_matrix > 0].flatten()
+
+            # build stack of times and fluxes
+            # `self._dts` and `all_d_fluxes` will have shape = (num_lightcurves, N)
+            self._dts.append(d_times)
+            all_d_fluxes.append(d_fluxes)
+
+        # combining treats all lightcurves as one when calculating the structure function
+        if self._argument_container.combine and len(self._time) > 1:
+            self._dts = np.hstack(np.array(self._dts, dtype="object"))
+            all_d_fluxes = np.hstack(np.array(all_d_fluxes, dtype="object"))
+
+            # binning
+            if self._bins is None:
+                self._bin_dts(self._dts)
+
+            # structure function at specific dt
+            # the line below will throw error if the bins are not covering the whole range
+            iqr, bin_edgs, _ = binned_statistic(
+                self._dts, all_d_fluxes, statistic=self.calculate_iqr_sf2_statistic, bins=self._bins
+            )
+
+            bin_counts, _, _ = binned_statistic(self._dts, all_d_fluxes, statistic="count", bins=self._bins)
+
+            sfs = iqr / np.sqrt(bin_counts - 1)
+
+            return [(bin_edgs[0:-1] + bin_edgs[1:]) / 2], [sfs]
+
+        # Not combining calculates structure function for each light curve independently
+        else:
+            # may want to raise warning if len(times) <=1 and combine was set true
+            sfs_all = []
+            t_all = []
+            for lc_idx in range(len(self._dts)):
+                if len(self._dts[lc_idx]) > 1:
+                    # binning
+                    self._bin_dts(self._dts[lc_idx])
+                    iqr, bin_edgs, _ = binned_statistic(
+                        self._dts[lc_idx],
+                        all_d_fluxes[lc_idx],
+                        statistic=self.calculate_iqr_sf2_statistic,
+                        bins=self._bins,
+                    )
+
+                    bin_counts, _, _ = binned_statistic(
+                        self._dts[lc_idx],
+                        all_d_fluxes[lc_idx],
+                        statistic="count",
+                        bins=self._bins,
+                    )
+
+                    sfs = iqr / np.sqrt(bin_counts - 1)
+
+                    sfs_all.append(sfs)
+                    t_all.append((bin_edgs[0:-1] + bin_edgs[1:]) / 2)
+                else:
+                    sfs_all.append(np.array([]))
+                    t_all.append(np.array([]))
+            return t_all, sfs_all
+
+    def calculate_iqr_sf2_statistic(self, input):
+        """For a given set of binned metrics (in this case delta fluxes) calculate
+        the interquartile range.
+
+        Parameters
+        ----------
+        input : `np.ndarray` (N,)
+            The delta flux values that correspond to a given delta time bin.
+
+        Returns
+        -------
+        float
+            Result of calculating IQR part of (Macleod et al. 2012) of Graham+ 16:
+            `0.74 * IQR`
+        """
+        # calculate interquartile range between 25% and 75%.
+        iqr = np.subtract(*np.percentile(input, [75, 25]))
+
+        return CONVERSION_TO_SIGMA * iqr
+
+    @staticmethod
+    def name_id() -> str:
+        return "macleod_2012"
+
+    @staticmethod
+    def expected_argument_container() -> type:
+        return StructureFunctionArgumentContainer

--- a/tests/lsstseries_tests/structure_function_calculators/test_base_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_base_calculator.py
@@ -11,7 +11,9 @@ def test_dt_bins():
     """
 
     arg_container = StructureFunctionArgumentContainer()
-    sf_method = BasicStructureFunctionCalculator([], [], [], argument_container=arg_container)
+    sf_method = BasicStructureFunctionCalculator(
+        np.atleast_2d([]), np.atleast_2d([]), np.atleast_2d([]), argument_container=arg_container
+    )
 
     # Test on some known data.
     dts = np.array([(201.0 - i) for i in range(200)])
@@ -22,7 +24,9 @@ def test_dt_bins():
 
     arg_container = StructureFunctionArgumentContainer()
     arg_container.bin_method = "length"
-    sf_method = BasicStructureFunctionCalculator([], [], [], argument_container=arg_container)
+    sf_method = BasicStructureFunctionCalculator(
+        np.atleast_2d([]), np.atleast_2d([]), np.atleast_2d([]), argument_container=arg_container
+    )
 
     sf_method._bin_dts(dts)
     bins = sf_method._bins
@@ -30,7 +34,9 @@ def test_dt_bins():
 
     arg_container = StructureFunctionArgumentContainer()
     arg_container.bin_method = "loglength"
-    sf_method = BasicStructureFunctionCalculator([], [], [], argument_container=arg_container)
+    sf_method = BasicStructureFunctionCalculator(
+        np.atleast_2d([]), np.atleast_2d([]), np.atleast_2d([]), argument_container=arg_container
+    )
 
     sf_method._bin_dts(dts)
     bins = sf_method._bins
@@ -43,7 +49,9 @@ def test_dt_bins_large_random():
     dts = np.random.random_sample(1000) * 5 + np.logspace(1, 2, 1000)
 
     arg_container = StructureFunctionArgumentContainer()
-    sf_method = BasicStructureFunctionCalculator([], [], [], argument_container=arg_container)
+    sf_method = BasicStructureFunctionCalculator(
+        np.atleast_2d([]), np.atleast_2d([]), np.atleast_2d([]), argument_container=arg_container
+    )
 
     # test size method
     sf_method._bin_dts(dts)
@@ -54,7 +62,9 @@ def test_dt_bins_large_random():
 
     arg_container = StructureFunctionArgumentContainer()
     arg_container.bin_method = "length"
-    sf_method = BasicStructureFunctionCalculator([], [], [], argument_container=arg_container)
+    sf_method = BasicStructureFunctionCalculator(
+        np.atleast_2d([]), np.atleast_2d([]), np.atleast_2d([]), argument_container=arg_container
+    )
 
     # test length method
     sf_method._bin_dts(dts)
@@ -63,7 +73,9 @@ def test_dt_bins_large_random():
 
     arg_container = StructureFunctionArgumentContainer()
     arg_container.bin_method = "loglength"
-    sf_method = BasicStructureFunctionCalculator([], [], [], argument_container=arg_container)
+    sf_method = BasicStructureFunctionCalculator(
+        np.atleast_2d([]), np.atleast_2d([]), np.atleast_2d([]), argument_container=arg_container
+    )
 
     sf_method._bin_dts(dts)
     bins = sf_method._bins
@@ -79,7 +91,9 @@ def test_dt_bins_raises_exception():
 
     arg_container = StructureFunctionArgumentContainer()
     arg_container.bin_method = "not_a_real_method"
-    sf_method = BasicStructureFunctionCalculator([], [], [], argument_container=arg_container)
+    sf_method = BasicStructureFunctionCalculator(
+        np.atleast_2d([]), np.atleast_2d([]), np.atleast_2d([]), argument_container=arg_container
+    )
 
     with pytest.raises(ValueError) as excinfo:
         _ = sf_method._bin_dts(dts)

--- a/tests/lsstseries_tests/structure_function_calculators/test_iqr_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_iqr_calculator.py
@@ -1,0 +1,20 @@
+import pytest
+import numpy as np
+
+from lsstseries.analysis.structure_function.iqr.calculator import IqrStructureFunctionCalculator
+from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
+
+
+def test_basic_calculation():
+    """Most basic test possible. Inputs are expected to be 2d numpy arrays."""
+
+    test_t = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    test_y = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.combine = False
+
+    sf_calculator = IqrStructureFunctionCalculator(test_t, test_y, None, arg_container)
+
+    res = sf_calculator.calculate()
+
+    assert res

--- a/tests/lsstseries_tests/structure_function_calculators/test_iqr_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_iqr_calculator.py
@@ -18,3 +18,32 @@ def test_basic_calculation():
     res = sf_calculator.calculate()
 
     assert res
+
+
+def test_calculate_iqr_method():
+    """This test is specifically for the
+    `IqrStructureFunctionCalculator.calculate_iqr_sf2_statistic` method.
+    We'll set up an instance of `IqrStructureFunctionCalculator`, but only so
+    we can get access to the method we want to test.
+
+    Because the function is only called by scipy.binned_statistics, we can be
+    more confident that the input type and shape will be consistent. Thus, there
+    are not a lot of unit tests around it to confirm the behavior for unexpected
+    inputs.
+    """
+
+    test_t = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    test_y = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.combine = False
+
+    sf_calculator = IqrStructureFunctionCalculator(test_t, test_y, None, arg_container)
+
+    test_input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    # 25th percentile of input = 2.25
+    # 75th percentile of input = 6.75
+    # 0.741 * (75th - 25th) = 3.3345
+    output = sf_calculator.calculate_iqr_sf2_statistic(test_input)
+
+    assert output == 3.3345

--- a/tests/lsstseries_tests/structure_function_calculators/test_macleod_2012_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_macleod_2012_calculator.py
@@ -1,0 +1,54 @@
+import pytest
+import numpy as np
+
+from lsstseries.analysis.structure_function.macleod_2012.calculator import (
+    Macleod2012StructureFunctionCalculator,
+)
+from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
+
+
+def test_basic_calculation():
+    """Most basic test possible. Inputs are expected to be 2d numpy arrays."""
+
+    test_t = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    test_y = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.combine = False
+
+    sf_calculator = Macleod2012StructureFunctionCalculator(test_t, test_y, None, arg_container)
+
+    res = sf_calculator.calculate()
+
+    assert res
+
+
+# TODO: This tests is a duplicate of a test in the test_iqr_calculator.py suite.
+# Seems like a good indication that the method being tested should be moved to
+# the base class and tested from there.
+def test_calculate_iqr_method():
+    """This test is specifically for the
+    `IqrStructureFunctionCalculator.calculate_iqr_sf2_statistic` method.
+    We'll set up an instance of `IqrStructureFunctionCalculator`, but only so
+    we can get access to the method we want to test.
+
+    Because the function is only called by scipy.binned_statistics, we can be
+    more confident that the input type and shape will be consistent. Thus, there
+    are not a lot of unit tests around it to confirm the behavior for unexpected
+    inputs.
+    """
+
+    test_t = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    test_y = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.combine = False
+
+    sf_calculator = Macleod2012StructureFunctionCalculator(test_t, test_y, None, arg_container)
+
+    test_input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    # 25th percentile of input = 2.25
+    # 75th percentile of input = 6.75
+    # 0.74 * (75th - 25th) = 3.33
+    output = sf_calculator.calculate_iqr_sf2_statistic(test_input)
+
+    assert output == 3.33

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -557,3 +557,23 @@ def test_sf2_base_case_iqr():
 
     assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.41126, rel=0.001)
+
+
+def test_sf2_base_case_macleod_2012():
+    """
+    Base test case accessing calc_sf2 directly. Uses `macleod_2012` SF
+    calculation method.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_y))
+    test_sf_method = "macleod_2012"
+
+    res = analysis.calc_sf2(
+        time=test_t, flux=test_y, err=test_yerr, band=test_band, lc_id=lc_id, sf_method=test_sf_method
+    )
+
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.07904, rel=0.001)

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -538,3 +538,22 @@ def test_validate_sf_method_raises_for_unknown_method():
         analysis.structurefunction2._validate_sf_method(input_sf_method, arg_container)
 
     assert "Unknown" in str(execinfo.value)
+
+
+def test_sf2_base_case_iqr():
+    """
+    Base test case accessing calc_sf2 directly. Uses `IQR` SF calculation method.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_y))
+    test_sf_method = "iqr"
+
+    res = analysis.calc_sf2(
+        time=test_t, flux=test_y, err=test_yerr, band=test_band, lc_id=lc_id, sf_method=test_sf_method
+    )
+
+    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.41126, rel=0.001)

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -510,3 +510,21 @@ def test_sf2(parquet_ensemble, method, combine, sthresh, use_map=False):
         assert not res_sf2.equals(res_batch)  # output should be different
     else:
         assert res_sf2.equals(res_batch)  # output should be identical
+
+
+@pytest.mark.parametrize("sf_method", ["basic", "iqr"])
+def test_sf2_methods(parquet_ensemble, sf_method, use_map=False):
+    """
+    Test calling sf2 from the ensemble
+    """
+
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.bin_method = "loglength"
+    arg_container.combine = False
+    arg_container.bin_count_target = 50
+    arg_container.sf_method = sf_method
+
+    res_sf2 = parquet_ensemble.sf2(argument_container=arg_container, use_map=use_map)
+    res_batch = parquet_ensemble.batch(calc_sf2, use_map=use_map, argument_container=arg_container)
+
+    assert res_sf2.equals(res_batch)  # output should be identical

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -512,7 +512,7 @@ def test_sf2(parquet_ensemble, method, combine, sthresh, use_map=False):
         assert res_sf2.equals(res_batch)  # output should be identical
 
 
-@pytest.mark.parametrize("sf_method", ["basic", "iqr"])
+@pytest.mark.parametrize("sf_method", ["basic", "iqr", "macleod_2012"])
 def test_sf2_methods(parquet_ensemble, sf_method, use_map=False):
     """
     Test calling sf2 from the ensemble


### PR DESCRIPTION
This PR is for a branch off of PR #100, so you'll see all of the same files changed here until PR #100 is merged to main. 

This PR implements what we are referring to as the Macleod_2012 Structure Function calculation method. It's described here (https://arxiv.org/pdf/1401.1785.pdf) as equation "Macleod et al. 2012". Namely: `SF(delta_t) = 0.741 * IQR / sqrt(N-1)` where IQR is the interquartile range of the sorted delta_flux values for a given bin of delta_t's. And `N` is the number of delta_t values in a given delta_t bin.

This calculator is able to make use of base SFArgumentContainer, so there was no need to implement a new subclass of the that dataclass. However, `Macleod2012StructureFunctionCalculator` is a new subclass of the `StructureFunctionCalculator`.
