### PR TITLE
Move duplicated binning logic out of the SF child classes into parent class.

### DIFF
--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -97,16 +97,16 @@ class StructureFunctionCalculator(ABC):
 
         Parameters
         ----------
-        statistict_to_apply : str or function, optional
+        statistic_to_apply : str or function, optional
             The statistic to apply to the values in each delta_t bin, by default
             "mean".
 
         Returns
         -------
-        (`np.ndarray`, `np.ndarray`)
-            A tuple of two numpy arrays.
-            The first array contains the center of the delta_t bins.
-            The second array contains the result of evaluating the
+        (`List[float]`, List[float]`)
+            A tuple of two lists.
+            The first list contains the center of the delta_t bins.
+            The second list contains the result of evaluating the
             statistic measure on the delta_flux values in each delta_t bin.
         """
 

--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -103,10 +103,11 @@ class StructureFunctionCalculator(ABC):
 
         Returns
         -------
-        Two List[floats]
-            The first list returned defines the center of the delta_t bins.
-            The second list returned contains the result of evaluating the
-            statistic measure of the delta_flux values in each delta_t bin.
+        (`np.ndarray`, `np.ndarray`)
+            A tuple of two numpy arrays.
+            The first array contains the center of the delta_t bins.
+            The second array contains the result of evaluating the
+            statistic measure on the delta_flux values in each delta_t bin.
         """
 
         # combining treats all lightcurves as one when calculating the structure function

--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -103,7 +103,7 @@ class StructureFunctionCalculator(ABC):
 
         Returns
         -------
-        (`List[float]`, List[float]`)
+        (`List[float]`, `List[float]`)
             A tuple of two lists.
             The first list contains the center of the delta_t bins.
             The second list contains the result of evaluating the

--- a/src/lsstseries/analysis/structure_function/basic/calculator.py
+++ b/src/lsstseries/analysis/structure_function/basic/calculator.py
@@ -65,39 +65,11 @@ class BasicStructureFunctionCalculator(StructureFunctionCalculator):
 
             # build stack of times and fluxes
             self._dts.append(d_times)
-            cor_flux2_all.append(cor_flux2)
+            self._all_d_fluxes.append(cor_flux2)
 
-        # combining treats all lightcurves as one when calculating the structure function
-        if self._argument_container.combine and len(self._time) > 1:
-            self._dts = np.hstack(np.array(self._dts, dtype="object"))
-            cor_flux2_all = np.hstack(np.array(cor_flux2_all, dtype="object"))
+        dts, sfs = self._calculate_binned_statistics()
 
-            # binning
-            if self._bins is None:
-                self._bin_dts(self._dts)
-
-            # structure function at specific dt
-            # the line below will throw error if the bins are not covering the whole range
-            sfs, bin_edgs, _ = binned_statistic(self._dts, cor_flux2_all, "mean", self._bins)
-            return [(bin_edgs[0:-1] + bin_edgs[1:]) / 2], [sfs]
-        # Not combining calculates structure function for each light curve independently
-        else:
-            # may want to raise warning if len(times) <=1 and combine was set true
-            sfs_all = []
-            t_all = []
-            for lc_idx in range(len(self._dts)):
-                if len(self._dts[lc_idx]) > 1:
-                    # binning
-                    self._bin_dts(self._dts[lc_idx])
-                    sfs, bin_edgs, _ = binned_statistic(
-                        self._dts[lc_idx], cor_flux2_all[lc_idx], "mean", self._bins
-                    )
-                    sfs_all.append(sfs)
-                    t_all.append((bin_edgs[0:-1] + bin_edgs[1:]) / 2)
-                else:
-                    sfs_all.append(np.array([]))
-                    t_all.append(np.array([]))
-            return t_all, sfs_all
+        return dts, sfs
 
     @staticmethod
     def name_id() -> str:

--- a/src/lsstseries/analysis/structure_function/macleod_2012/calculator.py
+++ b/src/lsstseries/analysis/structure_function/macleod_2012/calculator.py
@@ -1,7 +1,6 @@
 from typing import List
 
 import numpy as np
-from scipy.stats import binned_statistic
 
 from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
 from lsstseries.analysis.structure_function.base_calculator import StructureFunctionCalculator
@@ -34,7 +33,6 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
         super().__init__(time, flux, err, argument_container)
 
     def calculate(self):
-        all_d_fluxes = []
         for lc_idx in range(len(self._time)):
             lc_times = self._time[lc_idx]
             lc_fluxes = self._flux[lc_idx]
@@ -58,45 +56,11 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
             # build stack of times and fluxes
             # `self._dts` and `all_d_fluxes` will have shape = (num_lightcurves, N)
             self._dts.append(d_times)
-            all_d_fluxes.append(d_fluxes)
+            self._all_d_fluxes.append(d_fluxes)
 
-        # combining treats all lightcurves as one when calculating the structure function
-        if self._argument_container.combine and len(self._time) > 1:
-            self._dts = np.hstack(np.array(self._dts, dtype="object"))
-            all_d_fluxes = np.hstack(np.array(all_d_fluxes, dtype="object"))
+        dts, sfs = self._calculate_binned_statistics(statistic_to_apply=self.calculate_iqr_sf2_statistic)
 
-            # binning
-            if self._bins is None:
-                self._bin_dts(self._dts)
-
-            # structure function at specific dt
-            # the line below will throw error if the bins are not covering the whole range
-            sfs, bin_edgs, _ = binned_statistic(
-                self._dts, all_d_fluxes, statistic=self.calculate_iqr_sf2_statistic, bins=self._bins
-            )
-            return [(bin_edgs[0:-1] + bin_edgs[1:]) / 2], [sfs]
-
-        # Not combining calculates structure function for each light curve independently
-        else:
-            # may want to raise warning if len(times) <=1 and combine was set true
-            sfs_all = []
-            t_all = []
-            for lc_idx in range(len(self._dts)):
-                if len(self._dts[lc_idx]) > 1:
-                    # binning
-                    self._bin_dts(self._dts[lc_idx])
-                    sfs, bin_edgs, _ = binned_statistic(
-                        self._dts[lc_idx],
-                        all_d_fluxes[lc_idx],
-                        statistic=self.calculate_iqr_sf2_statistic,
-                        bins=self._bins,
-                    )
-                    sfs_all.append(sfs)
-                    t_all.append((bin_edgs[0:-1] + bin_edgs[1:]) / 2)
-                else:
-                    sfs_all.append(np.array([]))
-                    t_all.append(np.array([]))
-            return t_all, sfs_all
+        return dts, sfs
 
     def calculate_iqr_sf2_statistic(self, input):
         """For a given set of binned metrics (in this case delta fluxes) calculate


### PR DESCRIPTION
This does not address issue #102, it is only an effort to reduce code duplication. All of the unit test are untouched, and pass as expected. 

The long story is that after implementing the first Structure Function calculator, I didn't know what code would likely be duplicated. But after implementing the second, I spotted some of the duplication. Thus in an effort to reduce that duplication, this PR was created. 