### PR TITLE
Return `mean(delta_t values in bin)` as `dts` for Structure Function

### DIFF
--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -146,8 +146,8 @@ class StructureFunctionCalculator(ABC):
                 )
 
             # return the mean delta_time values for each bin
-            # bin_means, _, _ = binned_statistic(self._dts, self._dts, statistic="mean", bins=self._bins)
-            return [(bin_edgs[0:-1] + bin_edgs[1:]) / 2], [sfs]
+            bin_means, _, _ = binned_statistic(self._dts, self._dts, statistic="mean", bins=self._bins)
+            return [bin_means], [sfs]
 
         # Not combining calculates structure function for each light curve independently
         else:
@@ -175,14 +175,14 @@ class StructureFunctionCalculator(ABC):
                     sfs_all.append(sfs)
 
                     # return the mean delta_time values for each bin
-                    # bin_means, _, _ = binned_statistic(
-                    #     self._dts[lc_idx],
-                    #     self._dts[lc_idx],
-                    #     statistic="mean",
-                    #     bins=self._bins,
-                    # )
+                    bin_means, _, _ = binned_statistic(
+                        self._dts[lc_idx],
+                        self._dts[lc_idx],
+                        statistic="mean",
+                        bins=self._bins,
+                    )
 
-                    t_all.append((bin_edgs[0:-1] + bin_edgs[1:]) / 2)
+                    t_all.append(bin_means)
                 else:
                     sfs_all.append(np.array([]))
                     t_all.append(np.array([]))

--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -104,7 +104,7 @@ class StructureFunctionCalculator(ABC):
         -------
         (`List[float]`, `List[float]`)
             A tuple of two lists.
-            The first list contains the center of the delta_t bins.
+            The first list contains the mean of the delta_t values in each bin.
             The second list contains the result of evaluating the
             statistic measure on the delta_flux values in each delta_t bin.
 

--- a/tests/lsstseries_tests/structure_function_calculators/test_bauer_2009a_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_bauer_2009a_calculator.py
@@ -39,5 +39,5 @@ def test_sf2_base_case_bauer_2009a():
         time=test_t, flux=test_y, err=test_yerr, band=test_band, lc_id=lc_id, sf_method=test_sf_method
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.0732, rel=0.001)

--- a/tests/lsstseries_tests/structure_function_calculators/test_bauer_2009b_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_bauer_2009b_calculator.py
@@ -39,5 +39,5 @@ def test_sf2_base_case_bauer_2009b():
         time=test_t, flux=test_y, err=test_yerr, band=test_band, lc_id=lc_id, sf_method=test_sf_method
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.1502, rel=0.001)

--- a/tests/lsstseries_tests/structure_function_calculators/test_schmidt_2010_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_schmidt_2010_calculator.py
@@ -39,5 +39,5 @@ def test_sf2_base_case_schmidt_2010():
         time=test_t, flux=test_y, err=test_yerr, band=test_band, lc_id=lc_id, sf_method=test_sf_method
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.1714, rel=0.001)

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -49,7 +49,7 @@ def test_sf2_timeseries(lc_id):
 
     res = test_series.sf2()
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -74,7 +74,7 @@ def test_sf2_timeseries_without_timestamps():
     test_series = timeseries.from_dict(data_dict=test_dict)
     res = test_series.sf2()
 
-    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -99,7 +99,7 @@ def test_sf2_timeseries_with_all_none_timestamps():
     test_series = timeseries.from_dict(data_dict=test_dict)
     res = test_series.sf2()
 
-    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -122,7 +122,7 @@ def test_sf2_base_case():
         lc_id=lc_id,
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -145,7 +145,7 @@ def test_sf2_base_case_time_as_none_array():
         lc_id=lc_id,
     )
 
-    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -168,7 +168,7 @@ def test_sf2_base_case_time_as_none_scalar():
         lc_id=lc_id,
     )
 
-    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -191,7 +191,7 @@ def test_sf2_base_case_string_for_band_to_calc():
         time=test_t, flux=test_y, err=test_yerr, band=test_band, lc_id=lc_id, argument_container=arg_container
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -214,7 +214,7 @@ def test_sf2_base_case_error_as_scalar():
         lc_id=lc_id,
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.152482, rel=0.001)
 
 
@@ -237,7 +237,7 @@ def test_sf2_base_case_error_as_none():
         lc_id=lc_id,
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.172482, rel=0.001)
 
 
@@ -258,7 +258,7 @@ def test_sf2_no_lightcurve_ids():
         band=test_band,
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -279,7 +279,7 @@ def test_sf2_no_band_information():
         lc_id=lc_id,
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
 
 
@@ -296,7 +296,7 @@ def test_sf2_least_possible_information():
         flux=test_y,
     )
 
-    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.172482, rel=0.001)
 
 
@@ -310,7 +310,7 @@ def test_sf2_least_possible_information_constant_flux():
 
     res = analysis.calc_sf2(time=None, flux=test_y)
 
-    assert res["dt"][0] == pytest.approx(4.0, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.0, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.0, rel=0.001)
 
 
@@ -555,5 +555,5 @@ def test_sf2_base_case_macleod_2012():
         time=test_t, flux=test_y, err=test_yerr, band=test_band, lc_id=lc_id, sf_method=test_sf_method
     )
 
-    assert res["dt"][0] == pytest.approx(3.705, rel=0.001)
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.4107, rel=0.001)


### PR DESCRIPTION
In the main branch after we have established the bins for the time differences, we return the bin centers to the user as the parameter `dts`. However, in practice this value can be misleading, and it is more useful to return the mean of the values in a given bin as the parameter `dts`. 

This PR represents the work to gather those statistics for the bins. There were several unit tests that needed to be updated as well, but because we were using small, contrived examples, it was not difficult to verify that the new `dts` values were correct. 