### PR TITLE
Fixes bug that causes Structure Function to ignore user provided time bins.

### DIFF
--- a/src/lsstseries/analysis/structure_function/base_calculator.py
+++ b/src/lsstseries/analysis/structure_function/base_calculator.py
@@ -168,7 +168,7 @@ class StructureFunctionCalculator(ABC):
             # structure function at specific dt
             # the line below will throw error if the bins are not covering the whole range
             try:
-                sfs, bin_edgs, _ = binned_statistic(
+                sfs, _, _ = binned_statistic(
                     self._dts, sample_values, statistic=statistic_to_apply, bins=self._bins
                 )
             except AttributeError:
@@ -189,10 +189,12 @@ class StructureFunctionCalculator(ABC):
                 if len(self._dts[lc_idx]) > 1:
                     # bin the delta_time values, and evaluate the `statistic_to_apply`
                     # for the delta_flux values in each bin.
-                    self._bin_dts(self._dts[lc_idx])
+
+                    if self._bins is None:
+                        self._bin_dts(self._dts[lc_idx])
 
                     try:
-                        sfs, bin_edgs, _ = binned_statistic(
+                        sfs, _, _ = binned_statistic(
                             self._dts[lc_idx],
                             sample_values[lc_idx],
                             statistic=statistic_to_apply,

--- a/tests/lsstseries_tests/structure_function_calculators/test_base_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_base_calculator.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pytest
 
+from lsstseries.analysis.structure_function.base_calculator import (
+    StructureFunctionCalculator,
+    register_sf_subclasses,
+)
 from lsstseries.analysis.structure_function.base_argument_container import StructureFunctionArgumentContainer
 from lsstseries.analysis.structure_function.basic.calculator import BasicStructureFunctionCalculator
 
@@ -171,3 +175,30 @@ def test_calculate_binned_statistics_raises_individual():
     with pytest.raises(AttributeError) as excinfo:
         _ = sf_method._calculate_binned_statistics(test_sample_values)
     assert "Length of each self._dts" in str(excinfo.value)
+
+
+def test_register_sf_subclasses():
+    """Base test to ensure that we register the most basic subclass of
+    StructureFunctionCalculator
+    """
+    output = register_sf_subclasses()
+    assert output["basic"] == BasicStructureFunctionCalculator
+
+
+def test_register_sf_subclasses_duplicate_name():
+    """Create an child class of StructureFunctionCalculator with an intentionally
+    duplicate name to check the assertion of `register_sf_subclasses`.
+    """
+
+    class DuplicateStructureFunction(StructureFunctionCalculator):
+        def calculate(self):
+            return 1
+
+        @staticmethod
+        def name_id():
+            return "basic"
+
+    with pytest.raises(ValueError) as excinfo:
+        _ = register_sf_subclasses()
+
+    assert "Attempted to add duplicate Structure" in str(excinfo.value)

--- a/tests/lsstseries_tests/test_analysis.py
+++ b/tests/lsstseries_tests/test_analysis.py
@@ -557,3 +557,88 @@ def test_sf2_base_case_macleod_2012():
 
     assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
     assert res["sf2"][0] == pytest.approx(0.4107, rel=0.001)
+
+
+def test_sf2_multiple_bands():
+    """
+    Starts with the base case test, but duplicates the test_t, test_y and test_err
+    for a second color band.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2, 1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2, 0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [
+        0.1,
+        0.023,
+        0.045,
+        0.1,
+        0.067,
+        0.032,
+        0.8,
+        0.02,
+        0.1,
+        0.023,
+        0.045,
+        0.1,
+        0.067,
+        0.032,
+        0.8,
+        0.02,
+    ]
+    test_band = np.array(
+        [
+            "r",
+            "r",
+            "r",
+            "r",
+            "r",
+            "r",
+            "r",
+            "r",
+            "g",
+            "g",
+            "g",
+            "g",
+            "g",
+            "g",
+            "g",
+            "g",
+        ]
+    )
+
+    res = analysis.calc_sf2(
+        time=test_t,
+        flux=test_y,
+        err=test_yerr,
+        band=test_band,
+        lc_id=lc_id,
+    )
+
+    assert res["dt"][0] == pytest.approx(3.1482, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.005365, rel=0.001)
+    assert res["dt"][1] == pytest.approx(3.1482, rel=0.001)
+    assert res["sf2"][1] == pytest.approx(0.005365, rel=0.001)
+
+
+def test_sf2_provide_bins_in_argument_container():
+    """
+    Base test case accessing calc_sf2 directly. Does not make use of TimeSeries
+    or Ensemble.
+    """
+    lc_id = [1, 1, 1, 1, 1, 1, 1, 1]
+    test_t = [1.11, 2.23, 3.45, 4.01, 5.67, 6.32, 7.88, 8.2]
+    test_y = [0.11, 0.23, 0.45, 0.01, 0.67, 0.32, 0.88, 0.2]
+    test_yerr = [0.1, 0.023, 0.045, 0.1, 0.067, 0.032, 0.8, 0.02]
+    test_band = np.array(["r"] * len(test_y))
+
+    arg_container = StructureFunctionArgumentContainer()
+    arg_container.bins = [0.0, 3.1, 9.0]
+
+    res = analysis.calc_sf2(
+        time=test_t, flux=test_y, err=test_yerr, band=test_band, lc_id=lc_id, argument_container=arg_container
+    )
+
+    assert res["dt"][0] == pytest.approx(1.7581, rel=0.001)
+    assert res["sf2"][0] == pytest.approx(0.0103, rel=0.001)
+    assert res["dt"][1] == pytest.approx(5.0017, rel=0.001)
+    assert res["sf2"][1] == pytest.approx(-0.001216, rel=0.001)

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -522,6 +522,7 @@ def test_sf2(parquet_ensemble, method, combine, sthresh, use_map=False):
     else:
         assert res_sf2.equals(res_batch)  # output should be identical
 
+
 @pytest.mark.parametrize("sf_method", ["basic", "macleod_2012", "bauer_2009a", "bauer_2009b", "schmidt_2010"])
 def test_sf2_methods(parquet_ensemble, sf_method, use_map=False):
     """


### PR DESCRIPTION
In the non-combined mode of Structure Function calculations, we would ignore user provided bins in the `argument_container` and instead always calculate the bins. This PR fixes that bug and introduces regression unit tests. 