### PR TITLE
Consolidate duplicated Structure Function code into `base_calculator.py`.

### DIFF
--- a/src/lsstseries/analysis/structure_function/basic/calculator.py
+++ b/src/lsstseries/analysis/structure_function/basic/calculator.py
@@ -27,45 +27,14 @@ class BasicStructureFunctionCalculator(StructureFunctionCalculator):
         super().__init__(time, flux, err, argument_container)
 
     def calculate(self):
-        for lc_idx in range(len(self._time)):
-            lc_times = self._time[lc_idx]
-            lc_fluxes = self._flux[lc_idx]
-            lc_errors = self._err[lc_idx]
+        self._compute_difference_arrays()
 
-            # mask out any nan values
-            t_mask = np.isnan(lc_times)
-            f_mask = np.isnan(lc_fluxes)
-            e_mask = np.isnan(lc_errors)  # always mask out nan errors?
-            lc_mask = np.logical_or(t_mask, f_mask, e_mask)
+        values_to_be_binned = [
+            np.square(d_flux) - error_squared
+            for d_flux, error_squared in zip(self._all_d_fluxes, self._sum_error_squared)
+        ]
 
-            lc_times = lc_times[~lc_mask]
-            lc_fluxes = lc_fluxes[~lc_mask]
-            lc_errors = lc_errors[~lc_mask]
-
-            # compute d_times (difference of times) and
-            # d_fluxes (difference of magnitudes, i.e., fluxes) for all gaps
-            # d_times - difference of times
-            dt_matrix = lc_times.reshape((1, lc_times.size)) - lc_times.reshape((lc_times.size, 1))
-            d_times = dt_matrix[dt_matrix > 0].flatten()
-
-            # d_fluxes - difference of fluxes
-            df_matrix = lc_fluxes.reshape((1, lc_fluxes.size)) - lc_fluxes.reshape((lc_fluxes.size, 1))
-            d_fluxes = df_matrix[dt_matrix > 0].flatten()
-
-            # err^2 - errors squared
-            err2_matrix = (
-                lc_errors.reshape((1, lc_errors.size)) ** 2 + lc_errors.reshape((lc_errors.size, 1)) ** 2
-            )
-            err2s = err2_matrix[dt_matrix > 0].flatten()
-
-            # corrected each pair of observations
-            cor_flux2 = d_fluxes**2 - err2s
-
-            # build stack of times and fluxes
-            self._dts.append(d_times)
-            self._all_d_fluxes.append(cor_flux2)
-
-        dts, sfs = self._calculate_binned_statistics()
+        dts, sfs = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 
         return dts, sfs
 

--- a/src/lsstseries/analysis/structure_function/bauer_2009a/calculator.py
+++ b/src/lsstseries/analysis/structure_function/bauer_2009a/calculator.py
@@ -15,48 +15,14 @@ class Bauer2009AStructureFunctionCalculator(StructureFunctionCalculator):
     """
 
     def calculate(self):
-        err2_values = []
-        for lc_idx in range(len(self._time)):
-            lc_times = self._time[lc_idx]
-            lc_fluxes = self._flux[lc_idx]
-            lc_errors = self._err[lc_idx]
+        self._compute_difference_arrays()
 
-            # mask out any nan values
-            t_mask = np.isnan(lc_times)
-            f_mask = np.isnan(lc_fluxes)
-            e_mask = np.isnan(lc_errors)  # always mask out nan errors?
-            lc_mask = np.logical_or(t_mask, f_mask, e_mask)
-
-            lc_times = lc_times[~lc_mask]
-            lc_fluxes = lc_fluxes[~lc_mask]
-            lc_errors = lc_errors[~lc_mask]
-
-            # compute d_times - difference of times
-            dt_matrix = lc_times.reshape((1, lc_times.size)) - lc_times.reshape((lc_times.size, 1))
-            d_times = dt_matrix[dt_matrix > 0].flatten()
-
-            # d_fluxes - difference of fluxes
-            df_matrix = lc_fluxes.reshape((1, lc_fluxes.size)) - lc_fluxes.reshape((lc_fluxes.size, 1))
-            d_fluxes = df_matrix[dt_matrix > 0].flatten()
-
-            # err^2 - errors squared
-            err2_matrix = (
-                lc_errors.reshape((1, lc_errors.size)) ** 2 + lc_errors.reshape((lc_errors.size, 1)) ** 2
-            )
-            err2s = err2_matrix[dt_matrix > 0].flatten()
-
-            # build stacks of time and flux differences and errors
-            self._dts.append(d_times)
-            self._all_d_fluxes.append(np.square(d_fluxes))
-            err2_values.append(err2s)
-
-        # gather the means of the delta_fluxes per bin
-        dts, mean_d_flux_per_bin = self._calculate_binned_statistics(statistic_to_apply="mean")
+        # gather the means of the squared delta_fluxes per bin
+        value_to_be_binned = [np.square(d_flux) for d_flux in self._all_d_fluxes]
+        dts, mean_d_flux_per_bin = self._calculate_binned_statistics(sample_values=value_to_be_binned)
 
         # gather the means of the sigma^2 (error) per bin
-        _, mean_err2_per_bin = self._calculate_binned_statistics(
-            sample_values=err2_values, statistic_to_apply="mean"
-        )
+        _, mean_err2_per_bin = self._calculate_binned_statistics(sample_values=self._sum_error_squared)
 
         # calculate the structure function
         sfs = np.sqrt(np.asarray(mean_d_flux_per_bin) - np.asarray(mean_err2_per_bin))

--- a/src/lsstseries/analysis/structure_function/bauer_2009b/calculator.py
+++ b/src/lsstseries/analysis/structure_function/bauer_2009b/calculator.py
@@ -17,48 +17,14 @@ class Bauer2009BStructureFunctionCalculator(StructureFunctionCalculator):
     """
 
     def calculate(self):
-        err2_values = []
-        for lc_idx in range(len(self._time)):
-            lc_times = self._time[lc_idx]
-            lc_fluxes = self._flux[lc_idx]
-            lc_errors = self._err[lc_idx]
+        self._compute_difference_arrays()
 
-            # mask out any nan values
-            t_mask = np.isnan(lc_times)
-            f_mask = np.isnan(lc_fluxes)
-            e_mask = np.isnan(lc_errors)  # always mask out nan errors?
-            lc_mask = np.logical_or(t_mask, f_mask, e_mask)
-
-            lc_times = lc_times[~lc_mask]
-            lc_fluxes = lc_fluxes[~lc_mask]
-            lc_errors = lc_errors[~lc_mask]
-
-            # compute d_times - difference of times
-            dt_matrix = lc_times.reshape((1, lc_times.size)) - lc_times.reshape((lc_times.size, 1))
-            d_times = dt_matrix[dt_matrix > 0].flatten()
-
-            # d_fluxes - difference of fluxes
-            df_matrix = lc_fluxes.reshape((1, lc_fluxes.size)) - lc_fluxes.reshape((lc_fluxes.size, 1))
-            d_fluxes = df_matrix[dt_matrix > 0].flatten()
-
-            # err^2 - errors squared
-            err2_matrix = (
-                lc_errors.reshape((1, lc_errors.size)) ** 2 + lc_errors.reshape((lc_errors.size, 1)) ** 2
-            )
-            err2s = err2_matrix[dt_matrix > 0].flatten()
-
-            # build stacks of time and flux differences and errors
-            self._dts.append(d_times)
-            self._all_d_fluxes.append(np.abs(d_fluxes))
-            err2_values.append(err2s)
-
-        # gather the means of the delta_fluxes per bin
-        dts, mean_d_flux_per_bin = self._calculate_binned_statistics(statistic_to_apply="mean")
+        # gather the means of the abs(delta_fluxes) per bin
+        value_to_be_binned = [np.abs(d_flux) for d_flux in self._all_d_fluxes]
+        dts, mean_d_flux_per_bin = self._calculate_binned_statistics(sample_values=value_to_be_binned)
 
         # gather the means of the sigma^2 (error) per bin
-        _, mean_err2_per_bin = self._calculate_binned_statistics(
-            sample_values=err2_values, statistic_to_apply="mean"
-        )
+        _, mean_err2_per_bin = self._calculate_binned_statistics(sample_values=self._sum_error_squared)
 
         # calculate the structure function
         sfs = np.sqrt(PI_OVER_2 * np.square(mean_d_flux_per_bin) - mean_err2_per_bin)

--- a/src/lsstseries/analysis/structure_function/macleod_2012/calculator.py
+++ b/src/lsstseries/analysis/structure_function/macleod_2012/calculator.py
@@ -33,30 +33,7 @@ class Macleod2012StructureFunctionCalculator(StructureFunctionCalculator):
         super().__init__(time, flux, err, argument_container)
 
     def calculate(self):
-        for lc_idx in range(len(self._time)):
-            lc_times = self._time[lc_idx]
-            lc_fluxes = self._flux[lc_idx]
-
-            # mask out any nan values
-            t_mask = np.isnan(lc_times)
-            f_mask = np.isnan(lc_fluxes)
-            lc_mask = np.logical_or(t_mask, f_mask)
-
-            lc_times = lc_times[~lc_mask]
-            lc_fluxes = lc_fluxes[~lc_mask]
-
-            # compute difference of times
-            dt_matrix = lc_times.reshape((1, lc_times.size)) - lc_times.reshape((lc_times.size, 1))
-            d_times = dt_matrix[dt_matrix > 0].flatten()
-
-            # compute difference of fluxes, keep only where difference in time > 0
-            df_matrix = lc_fluxes.reshape((1, lc_fluxes.size)) - lc_fluxes.reshape((lc_fluxes.size, 1))
-            d_fluxes = df_matrix[dt_matrix > 0].flatten()
-
-            # build stack of times and fluxes
-            # `self._dts` and `all_d_fluxes` will have shape = (num_lightcurves, N)
-            self._dts.append(d_times)
-            self._all_d_fluxes.append(d_fluxes)
+        self._compute_difference_arrays()
 
         dts, sfs = self._calculate_binned_statistics(statistic_to_apply=self.calculate_iqr_sf2_statistic)
 

--- a/src/lsstseries/analysis/structure_function/schmidt_2010/calculator.py
+++ b/src/lsstseries/analysis/structure_function/schmidt_2010/calculator.py
@@ -18,41 +18,12 @@ class Schmidt2010StructureFunctionCalculator(StructureFunctionCalculator):
     """
 
     def calculate(self):
-        values_to_be_binned = []
-        for lc_idx in range(len(self._time)):
-            lc_times = self._time[lc_idx]
-            lc_fluxes = self._flux[lc_idx]
-            lc_errors = self._err[lc_idx]
+        self._compute_difference_arrays()
 
-            # mask out any nan values
-            t_mask = np.isnan(lc_times)
-            f_mask = np.isnan(lc_fluxes)
-            e_mask = np.isnan(lc_errors)  # always mask out nan errors?
-            lc_mask = np.logical_or(t_mask, f_mask, e_mask)
-
-            lc_times = lc_times[~lc_mask]
-            lc_fluxes = lc_fluxes[~lc_mask]
-            lc_errors = lc_errors[~lc_mask]
-
-            # compute d_times - difference of times
-            dt_matrix = lc_times.reshape((1, lc_times.size)) - lc_times.reshape((lc_times.size, 1))
-            d_times = dt_matrix[dt_matrix > 0].flatten()
-
-            # d_fluxes - difference of fluxes
-            df_matrix = lc_fluxes.reshape((1, lc_fluxes.size)) - lc_fluxes.reshape((lc_fluxes.size, 1))
-            d_fluxes = df_matrix[dt_matrix > 0].flatten()
-
-            # err^2 - errors squared
-            err2_matrix = (
-                lc_errors.reshape((1, lc_errors.size)) ** 2 + lc_errors.reshape((lc_errors.size, 1)) ** 2
-            )
-            err2s = err2_matrix[dt_matrix > 0].flatten()
-
-            # build stacks of time and flux differences and errors
-            self._dts.append(d_times)
-
-            calculated_values = SQRT_PI_OVER_2 * np.abs(d_fluxes) - np.sqrt(err2s)
-            values_to_be_binned.append(calculated_values)
+        values_to_be_binned = [
+            SQRT_PI_OVER_2 * np.abs(d_flux) - np.sqrt(error_squared)
+            for d_flux, error_squared in zip(self._all_d_fluxes, self._sum_error_squared)
+        ]
 
         dts, sfs = self._calculate_binned_statistics(sample_values=values_to_be_binned)
 

--- a/tests/lsstseries_tests/structure_function_calculators/test_macleod_2012_calculator.py
+++ b/tests/lsstseries_tests/structure_function_calculators/test_macleod_2012_calculator.py
@@ -11,10 +11,11 @@ def test_basic_calculation():
 
     test_t = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     test_y = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    test_e = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     arg_container = StructureFunctionArgumentContainer()
     arg_container.combine = False
 
-    sf_calculator = Macleod2012StructureFunctionCalculator(test_t, test_y, None, arg_container)
+    sf_calculator = Macleod2012StructureFunctionCalculator(test_t, test_y, test_e, arg_container)
 
     res = sf_calculator.calculate()
 
@@ -35,10 +36,11 @@ def test_calculate_macleod_2012_method():
 
     test_t = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     test_y = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    test_e = np.atleast_2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     arg_container = StructureFunctionArgumentContainer()
     arg_container.combine = False
 
-    sf_calculator = Macleod2012StructureFunctionCalculator(test_t, test_y, None, arg_container)
+    sf_calculator = Macleod2012StructureFunctionCalculator(test_t, test_y, test_e, arg_container)
 
     test_input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 


### PR DESCRIPTION
I realize that this PR looks nasty. 

Each of the different Structure Function calculator methods had a large block of duplicated code that has now been consolidated into base_calculator. 

Prior to starting on the work to subsample and bootstrap the data (issue #61), it is necessary to consolidate the code to avoid making complicated changed in 5 different places. 

It's good to note that all the unit tests still pass despite this large change, and now, there's 1/5 the amount of code to maintain. 

