### PR TITLE
Add filter operations

### DIFF
--- a/docs/notebooks/working_with_the_ensemble.ipynb
+++ b/docs/notebooks/working_with_the_ensemble.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +8,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -28,16 +26,17 @@
     "ens = Ensemble()  # initialize an ensemble object\n",
     "\n",
     "# Read in data from a parquet file\n",
-    "ens.from_parquet(\"../../tests/lsstseries_tests/data/source/test_source.parquet\",\n",
-    "                id_col='ps1_objid',\n",
-    "                time_col='midPointTai',\n",
-    "                flux_col='psFlux',\n",
-    "                err_col='psFluxErr',\n",
-    "                band_col='filterName')"
+    "ens.from_parquet(\n",
+    "    \"../../tests/lsstseries_tests/data/source/test_source.parquet\",\n",
+    "    id_col=\"ps1_objid\",\n",
+    "    time_col=\"midPointTai\",\n",
+    "    flux_col=\"psFlux\",\n",
+    "    err_col=\"psFluxErr\",\n",
+    "    band_col=\"filterName\",\n",
+    ")"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -45,7 +44,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -63,22 +61,18 @@
     "from lsstseries.utils import ColumnMapper\n",
     "\n",
     "# columns assigned manually\n",
-    "manual_colmap = ColumnMapper().assign(id_col='ps1_objid',\n",
-    "                                      time_col='midPointTai',\n",
-    "                                      flux_col='psFlux',\n",
-    "                                      err_col='psFluxErr',\n",
-    "                                      band_col='filterName')\n",
+    "manual_colmap = ColumnMapper().assign(\n",
+    "    id_col=\"ps1_objid\", time_col=\"midPointTai\", flux_col=\"psFlux\", err_col=\"psFluxErr\", band_col=\"filterName\"\n",
+    ")\n",
     "\n",
     "# columns assigned using known ZTF columns\n",
     "ztf_map = ColumnMapper().use_known_map(\"ZTF\")\n",
     "\n",
-    "#Pass the ColumnMapper along to read_parquet\n",
-    "ens.from_parquet(\"../../tests/lsstseries_tests/data/source/test_source.parquet\",\n",
-    "                 column_mapper=ztf_map)"
+    "# Pass the ColumnMapper along to read_parquet\n",
+    "ens.from_parquet(\"../../tests/lsstseries_tests/data/source/test_source.parquet\", column_mapper=ztf_map)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -87,7 +81,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -106,7 +99,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -119,11 +111,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.compute(\"source\") # Compute lets dask know we're ready to bring the data into memory"
+    "ens.compute(\"source\")  # Compute lets dask know we're ready to bring the data into memory"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -131,7 +122,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -141,7 +131,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -158,11 +147,10 @@
    "source": [
     "# Inspection\n",
     "\n",
-    "ens.info(verbose=True, memory_usage=True) # Grabs high level information about the dataframes\n"
+    "ens.info(verbose=True, memory_usage=True)  # Grabs high level information about the dataframes"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -175,7 +163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.head(\"object\", 5) # Grabs the first 5 rows of the object table"
+    "ens.head(\"object\", 5)  # Grabs the first 5 rows of the object table"
    ]
   },
   {
@@ -184,12 +172,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "ens.tail(\"source\", 5) # Grabs the last 5 rows of the source table"
+    "ens.tail(\"source\", 5)  # Grabs the last 5 rows of the source table"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -206,13 +192,14 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Filtering\n",
     "\n",
-    "Filtering encompasses any action that removes rows from the dataframe as a result of some determining threshold/criteria. The `Ensemble` provides a general filtering function, as shown below [TO DO]"
+    "The `Ensemble` provides a general filtering function `filter` that mirrors a Pandas or Dask `query` command. Specifically, the function takes a string that provides an expression indicating which rows to **keep**. As with other `Ensemble` functions, an optional `table` parameter allows you to filter on either the object or the source table.\n",
+    "\n",
+    "For example, the following code filters the sources to only include rows with a flux value above 18.2. It uses `ens._flux_col` to retrieve the name of the column with that information."
    ]
   },
   {
@@ -221,11 +208,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: GENERAL FILTER FUNCTION"
+    "ens.filter(f\"{ens._flux_col} > 18.2\", table=\"source\")\n",
+    "ens.compute(\"source\")"
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, we could use a Dask dataseries of Booleans to indicate which rows to *keep*. We can often compute these series as the result of some operation on the underlying tables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keep_rows = ens._source[ens._err_col] < 0.05\n",
+    "keep_rows.compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then pass that series to a `filter_from_series` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ens.filter_from_series(keep_rows, table=\"source\")\n",
+    "ens.compute(\"source\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -239,16 +260,15 @@
    "outputs": [],
    "source": [
     "# Cleaning nans\n",
-    "ens.dropna(threshold=1) # threshold is the number of nans present in a row needed to drop the row\n",
+    "ens.dropna(threshold=1)  # threshold is the number of nans present in a row needed to drop the row\n",
     "\n",
     "# Filtering on number of observations\n",
-    "ens.prune(threshold=50) # threshold is the number of observations needed to retain the object\n",
+    "ens.prune(threshold=50)  # threshold is the number of observations needed to retain the object\n",
     "\n",
     "ens.info(verbose=True)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -256,7 +276,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -273,12 +292,12 @@
    "source": [
     "# using lsstseries analysis functions\n",
     "from lsstseries.analysis import calc_stetson_J\n",
-    "res = ens.batch(calc_stetson_J, compute=True) # compute is set to true to execute immediately (non-lazily)\n",
+    "\n",
+    "res = ens.batch(calc_stetson_J, compute=True)  # compute is set to true to execute immediately (non-lazily)\n",
     "res"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -296,8 +315,9 @@
    "source": [
     "import numpy as np\n",
     "\n",
+    "\n",
     "# Defining a simple function\n",
-    "def my_flux_average(flux_array, band_array, method='mean'):\n",
+    "def my_flux_average(flux_array, band_array, method=\"mean\"):\n",
     "    \"\"\"Read in an array of fluxes, and return the average of the fluxes by band\"\"\"\n",
     "    res = {}\n",
     "    for band in np.unique(band_array):\n",
@@ -311,7 +331,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -325,12 +344,11 @@
    "outputs": [],
    "source": [
     "# Applying the function to the ensemble\n",
-    "res = ens.batch(my_flux_average, \"psFlux\", \"filterName\", compute=True, meta=None, method='median')\n",
+    "res = ens.batch(my_flux_average, \"psFlux\", \"filterName\", compute=True, meta=None, method=\"median\")\n",
     "res"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -343,15 +361,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens.client.close() # Tear down the ensemble client"
+    "ens.client.close()  # Tear down the ensemble client"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py310",
+   "display_name": "Python (.conda-seriesenv)",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-.conda-seriesenv-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/notebooks/working_with_the_ensemble.ipynb
+++ b/docs/notebooks/working_with_the_ensemble.ipynb
@@ -367,9 +367,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (.conda-seriesenv)",
+   "display_name": "py310",
    "language": "python",
-   "name": "conda-env-.conda-seriesenv-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -259,7 +259,8 @@ class Ensemble:
         return self
 
     def filter(self, expr, table="object"):
-        """Filter the rows of a table based on an expression.
+        """Filter the rows of a table based on an expression of
+        what information to *keep*.
 
         Parameters
         ----------
@@ -269,6 +270,17 @@ class Ensemble:
         table: `str`, optional
             A string indicating which table to filter.
             Should be one of "object" or "source".
+
+        Examples
+        --------
+        # Keep sources with flux above 100.0:
+        ens.filter("flux > 100", table="source")
+
+        # Keep sources in the green band:
+        ens.filter("band_col_name == 'g'", table="source")
+
+        # Filtering on the flux column without knowing its name:
+        ens.filter(f"{ens._flux_col} > 100", table="source")
         """
         self._lazy_sync_tables(table)
         if table == "object":

--- a/src/lsstseries/ensemble.py
+++ b/src/lsstseries/ensemble.py
@@ -270,8 +270,8 @@ class Ensemble:
         self._source_dirty = True  # This operation modifies the source table
         return self
 
-    def query(self, expr, table="object"):
-        """Select a subset of rows based on an expression.
+    def filter(self, expr, table="object"):
+        """Filter the rows of a table based on an expression.
 
         Parameters
         ----------

--- a/tests/lsstseries_tests/test_ensemble.py
+++ b/tests/lsstseries_tests/test_ensemble.py
@@ -385,7 +385,7 @@ def test_prune(parquet_ensemble):
     assert not np.any(parquet_ensemble._object["nobs_total"].values < threshold)
 
 
-def test_query(dask_client):
+def test_filter(dask_client):
     ens = Ensemble(client=dask_client)
 
     num_points = 1000
@@ -400,7 +400,7 @@ def test_query(dask_client):
     ens.from_source_dict(rows, column_mapper=cmap, npartitions=2)
 
     # Filter the data set to low flux sources only.
-    ens.query("flux <= 1.5", table="source")
+    ens.filter("flux <= 1.5", table="source")
 
     # Check that all of the filtered rows are value.
     (new_obj, new_source) = ens.compute()


### PR DESCRIPTION
Add filter operations for the tables by wrapping Dask DataFrame's `query` function and the ability to pass a series of Booleans.

Also adds a `_lazy_sync_table` function to simplify the logic when you only need to modify one table.
