### PR TITLE
Wrap Dask's Assign function

### DIFF
--- a/docs/notebooks/working_with_the_ensemble.ipynb
+++ b/docs/notebooks/working_with_the_ensemble.ipynb
@@ -311,6 +311,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Assignments and Column Manipulation\n",
+    "\n",
+    "The ensemble object supports assignment through the Dask `assign` function. We can pass in either a callable or a series to assign to the new column. New column names are produced automatically from the argument name.\n",
+    "\n",
+    "For example, if we want to compute the lower bound of an error range as the estimated flux minus twice the estimated error, we would use:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ens.assign(table=\"source\", lower_bnd=lambda x: x[\"psFlux\"] - 2.0 * x[\"psFluxErr\"])\n",
+    "ens.compute(table=\"source\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Batch Analysis\n",
     "\n",
     "The `Ensemble` provides a powerful batching interface, `Ensemble.batch`, with in-built parallelization (provided the input data is in multiple partitions). In addition, lsstseries has a suite of analysis functions on-hand for your use. Below, we show the application of `lsstseries.analysis.calc_stetson_J` on our dataset."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic=["version"]
 dependencies = [
     'pandas',
     'numpy',
-    'dask',
+    'dask>=2023.5.0',
     'dask[distributed]',
     'pyarrow',
     'pyvo',


### PR DESCRIPTION
Wrap Dask's `assign` function to allow users to construct new columns in either the source or object table.

Closes #44 
Also addresses part of #64 